### PR TITLE
Add recursive exclusions by utilizing fnmatch() module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # misc
 /aux
+
+# vscode
+.vscode/

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ More information about plugins in the [MkDocs documentation][mkdocs-plugins].
 
 ## Config
 
-- List the markdown files to be excluded under `exclude` using the format `filename.md`. Don't provide the directory of the file!
-- Exclude specific heading subsections using the format `filename.md#some-heading`. Chapter names are all lowercase, `-` as separator, no spaces.
-- Exclude all markdown files within a directory with `dirname/*.md` or `dirname/dirname2/*.md`.
+- List the markdown files to be excluded under `exclude` using the format `<path>/<to>/filename.md`.
+- Exclude specific heading subsections using the format `<path>/<to>/filename.md#some-heading`. Chapter names are all lowercase, `-` as separator, no spaces.
+- Exclude all markdown files within a directory (and its children) with `dirname/*.md` or `dirname/*`.
 - To only include a specific heading subsection of an excluded file, list the subsection under `ignore`. 
 
 ```yaml
@@ -31,7 +31,7 @@ plugins:
   - search
   - exclude-search:
       exclude:
-        - second.md  # Do not provide the directory of the file, only the filename!
+        - second.md
         - third.md#some-heading  
         - dir/*.md  # Only to exclude all files within a directory provide the directory!
         - dir2/sub/*.md

--- a/mkdocs_exclude_search/plugin.py
+++ b/mkdocs_exclude_search/plugin.py
@@ -59,7 +59,7 @@ class ExcludeSearch(BasePlugin):
         Resolve full search index chapter records from the user provided excluded files,
         chapters and directories ("*").
         """
-        to_exclude = [f.replace(".md", "") for f in to_exclude]
+        to_exclude = [f.replace(".md", ".html") for f in to_exclude]
         # TODO: This currently could exclude files with an excluded folder of the same name.
         for idx, entry in enumerate(to_exclude):
             if "#" in entry:

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,5 +2,5 @@ mkdocs-material
 pytest
 black
 twine
-mkdoc
+mkdocs
 git+https://github.com/jldiaz/mkdocs-plugin-tags.git

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="mkdocs-exclude-search",
-    version="0.3.1",
+    version="0.4.0",
     description="A mkdocs plugin that lets you exclude selected files or sections "
     "from the search index.",
     long_description=LONG_DESCRIPTION,

--- a/tests/mock_data/mock_search_index.json
+++ b/tests/mock_data/mock_search_index.json
@@ -9,134 +9,119 @@
   },
   "docs": [
     {
-      "location": "",
+      "location": "index.html",
       "text": "Index Hello, hello",
       "title": "index"
     },
     {
-      "location": "#index",
+      "location": "index.html#index",
       "text": "Hello, hello",
       "title": "Index"
     },
     {
-      "location": "chapter_exclude_all/",
+      "location": "chapter_exclude_all/exclude.html",
       "text": "Header chapter_exclude_all Aex header chapter_exclude_all AAex text chapter_exclude_all AAex header chapter_exclude_all BBex text chapter_exclude_all BBex",
       "title": "chapter_exclude_all"
     },
     {
-      "location": "chapter_exclude_all/#header-chapter_exclude_all-aex",
+      "location": "chapter_exclude_all/subdir/exclude.html",
+      "text": "Header chapter_exclude_all Aex header chapter_exclude_all AAex text chapter_exclude_all AAex header chapter_exclude_all BBex text chapter_exclude_all BBex in Subdir",
+      "title": "chapter_exclude_all_in_subdir"
+    },
+    {
+      "location": "chapter_exclude_all/index.html#header-chapter_exclude_all-aex",
       "text": "",
       "title": "Header chapter_exclude_all Aex"
     },
     {
-      "location": "chapter_exclude_all/#header-chapter_exclude_all-aaex",
+      "location": "chapter_exclude_all/index.html#header-chapter_exclude_all-aaex",
       "text": "text chapter_exclude_all AAex",
       "title": "header chapter_exclude_all AAex"
     },
     {
-      "location": "chapter_exclude_all/#header-chapter_exclude_all-bbex",
+      "location": "chapter_exclude_all/index.html#header-chapter_exclude_all-bbex",
       "text": "text chapter_exclude_all BBex",
       "title": "header chapter_exclude_all BBex"
     },
     {
-      "location": "chapter_exclude_heading2/",
+      "location": "chapter_exclude_heading2/index.html",
       "text": "single chapter_exclude_heading2 Header Ain single header chapter_exclude_heading2 AAin single text chapter_exclude_heading2 AAin single header chapter_exclude_heading2 BBex single text chapter_exclude_heading2 BBex",
       "title": "chapter_exclude_heading2"
     },
     {
-      "location": "chapter_exclude_heading2/#single-chapter_exclude_heading2-header-ain",
+      "location": "chapter_exclude_heading2/index.html#single-chapter_exclude_heading2-header-ain",
       "text": "",
       "title": "single chapter_exclude_heading2 Header Ain"
     },
     {
-      "location": "chapter_exclude_heading2/#single-header-chapter_exclude_heading2-aain",
+      "location": "chapter_exclude_heading2/index.html#single-header-chapter_exclude_heading2-aain",
       "text": "single text chapter_exclude_heading2 AAin",
       "title": "single header chapter_exclude_heading2 AAin"
     },
     {
-      "location": "chapter_exclude_heading2/#single-header-chapter_exclude_heading2-bbex",
+      "location": "chapter_exclude_heading2/index.html#single-header-chapter_exclude_heading2-bbex",
       "text": "single text chapter_exclude_heading2 BBex",
       "title": "single header chapter_exclude_heading2 BBex"
     },
     {
-      "location": "all_dir/all_dir/",
+      "location": "all_dir/all_dir/index.html",
       "text": "alldir Header all_dir Aex alldir header all_dir AAex alldir text all_dir AAex alldir header all_dir BBex alldir text all_dir BBex",
       "title": "all_dir"
     },
     {
-      "location": "all_dir/all_dir/#alldir-header-all_dir-aex",
+      "location": "all_dir/all_dir/index.html#alldir-header-all_dir-aex",
       "text": "",
       "title": "alldir Header all_dir Aex"
     },
     {
-      "location": "all_dir/all_dir/#alldir-header-all_dir-aaex",
+      "location": "all_dir/all_dir/index.html#alldir-header-all_dir-aaex",
       "text": "alldir text all_dir AAex",
       "title": "alldir header all_dir AAex"
     },
     {
-      "location": "all_dir/all_dir/#alldir-header-all_dir-bbex",
+      "location": "all_dir/all_dir/index.html#alldir-header-all_dir-bbex",
       "text": "alldir text all_dir BBex",
       "title": "alldir header all_dir BBex"
     },
     {
-      "location": "all_dir/all_dir_ignore_heading1/",
+      "location": "all_dir/all_dir_ignore_heading1/index.html",
       "text": "alldir Header all_dir_ignore_heading1 Aex alldir header all_dir_ignore_heading1 AAin alldir text all_dir_ignore_heading1 AAin alldir header all_dir_ignore_heading1 BBex alldir text all_dir_ignore_heading1 BBex",
       "title": "all_dir_ignore_heading1"
     },
     {
-      "location": "all_dir/all_dir_ignore_heading1/#alldir-header-all_dir_ignore_heading1-aex",
+      "location": "all_dir/all_dir_ignore_heading1/index.html#alldir-header-all_dir_ignore_heading1-aex",
       "text": "",
       "title": "alldir Header all_dir_ignore_heading1 Aex"
     },
     {
-      "location": "all_dir/all_dir_ignore_heading1/#alldir-header-all_dir_ignore_heading1-aain",
+      "location": "all_dir/all_dir_ignore_heading1/index.html#alldir-header-all_dir_ignore_heading1-aain",
       "text": "alldir text all_dir_ignore_heading1 AAin",
       "title": "alldir header all_dir_ignore_heading1 AAin"
     },
     {
-      "location": "all_dir/all_dir_ignore_heading1/#alldir-header-all_dir_ignore_heading1-bbex",
+      "location": "all_dir/all_dir_ignore_heading1/index.html#alldir-header-all_dir_ignore_heading1-bbex",
       "text": "alldir text all_dir_ignore_heading1 BBex",
       "title": "alldir header all_dir_ignore_heading1 BBex"
     },
     {
-      "location": "all_dir_sub/all_dir_sub2/all_dir_sub2_1/",
+      "location": "all_dir_sub/all_dir_sub2/all_dir_sub2_1/index.html",
       "text": "alldir Header all_dir_sub2 Aex alldir header all_dir_sub2 AAex alldir text all_dir_sub2 AAex alldir header all_dir_sub2 BBex alldir text all_dir_sub2 BBex",
       "title": "all_dir_sub2"
     },
     {
-      "location": "all_dir_sub/all_dir_sub2/all_dir_sub2_1/#alldir-header-all_dir_sub2-aex",
+      "location": "all_dir_sub/all_dir_sub2/all_dir_sub2_1/index.html#alldir-header-all_dir_sub2-aex",
       "text": "",
       "title": "alldir Header all_dir_sub2 Aex"
     },
     {
-      "location": "all_dir_sub/all_dir_sub2/all_dir_sub2_1/#alldir-header-all_dir_sub2-aaex",
+      "location": "all_dir_sub/all_dir_sub2/all_dir_sub2_1/index.html#alldir-header-all_dir_sub2-aaex",
       "text": "alldir text all_dir_sub2 AAex",
       "title": "alldir header all_dir_sub2 AAex"
     },
     {
-      "location": "all_dir_sub/all_dir_sub2/all_dir_sub2_1/#alldir-header-all_dir_sub2-bbex",
+      "location": "all_dir_sub/all_dir_sub2/all_dir_sub2_1/index.html#alldir-header-all_dir_sub2-bbex",
       "text": "alldir text all_dir_sub2 BBex",
       "title": "alldir header all_dir_sub2 BBex"
-    },
-    {
-      "location": "dir/dir_chapter_exclude_all/",
-      "text": "dir Header dir_chapter_exclude_all Aex dir header dir_chapter_exclude_all AAex dir text dir_chapter_exclude_all AAex dir header dir_chapter_exclude_all BBex dir text dir_chapter_exclude_all BBex",
-      "title": "dir_chapter_exclude_all"
-    },
-    {
-      "location": "dir/dir_chapter_exclude_all/#dir-header-dir_chapter_exclude_all-aex",
-      "text": "",
-      "title": "dir Header dir_chapter_exclude_all Aex"
-    },
-    {
-      "location": "dir/dir_chapter_exclude_all/#dir-header-dir_chapter_exclude_all-aaex",
-      "text": "dir text dir_chapter_exclude_all AAex",
-      "title": "dir header dir_chapter_exclude_all AAex"
-    },
-    {
-      "location": "dir/dir_chapter_exclude_all/#dir-header-dir_chapter_exclude_all-bbex",
-      "text": "dir text dir_chapter_exclude_all BBex",
-      "title": "dir header dir_chapter_exclude_all BBex"
     },
     {
       "location": "dir/dir_chapter_ignore_heading3/",

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -8,21 +8,19 @@ from mkdocs_exclude_search.plugin import ExcludeSearch
 
 CONFIG = {"plugins": ["search"]}
 TO_EXCLUDE = [
-    "chapter_exclude_all.md",
-    "chapter_exclude_heading2.md#single-header-chapter_exclude_heading2-bbex",
-    "dir_chapter_exclude_all.md",
+    "chapter_exclude_all/*",
+    "chapter_exclude_heading2/*#single-header-chapter_exclude_heading2-bbex",
     "dir_chapter_ignore_heading3.md",
-    "all_dir/*.md",
+    "all_dir/*.md#alldir-header-all_dir_ignore_heading1-aain",
     "all_dir_sub/all_dir_sub2/*.md",
 ]
 
 RESOLVED_EXCLUDED_RECORDS = [
-    "chapter_exclude_all",
-    "chapter_exclude_heading2#single-header-chapter_exclude_heading2-bbex",
-    "dir_chapter_exclude_all",
-    "dir_chapter_ignore_heading3",
-    "all_dir",
-    "all_dir_suball_dir_sub2",
+    ["chapter_exclude_all/*", None],
+    ["chapter_exclude_heading2/*", "single-header-chapter_exclude_heading2-bbex"],
+    ["dir_chapter_ignore_heading3", None],
+    ["all_dir/*", "alldir-header-all_dir_ignore_heading1-aain"],
+    ["all_dir_sub/all_dir_sub2/*", None],
 ]
 
 TO_IGNORE = [
@@ -40,42 +38,78 @@ RESOLVED_IGNORED_CHAPTERS = [
 EXCLUDE_TAGS = False
 
 INCLUDED_RECORDS = [
-    {"location": "", "text": "Index Hello, hello", "title": "index"},
-    {"location": "#index", "text": "Hello, hello", "title": "Index"},
+    {"location": "index.html", "text": "Index Hello, hello", "title": "index"},
+    {"location": "index.html#index", "text": "Hello, hello", "title": "Index"},
     {
-        "location": "chapter_exclude_heading2/",
-        "text": "single chapter_exclude_heading2 Header Ain single header chapter_exclude_heading2 AAin single text chapter_exclude_heading2 AAin single header chapter_exclude_heading2 BBex single text chapter_exclude_heading2 BBex",
-        "title": "chapter_exclude_heading2",
+      "location": "chapter_exclude_heading2/index.html",
+      "text": "single chapter_exclude_heading2 Header Ain single header chapter_exclude_heading2 AAin single text chapter_exclude_heading2 AAin single header chapter_exclude_heading2 BBex single text chapter_exclude_heading2 BBex",
+      "title": "chapter_exclude_heading2"
     },
     {
-        "location": "chapter_exclude_heading2/#single-chapter_exclude_heading2-header-ain",
-        "text": "",
-        "title": "single chapter_exclude_heading2 Header Ain",
+      "location": "chapter_exclude_heading2/index.html#single-chapter_exclude_heading2-header-ain",
+      "text": "",
+      "title": "single chapter_exclude_heading2 Header Ain"
     },
     {
-        "location": "chapter_exclude_heading2/#single-header-chapter_exclude_heading2-aain",
-        "text": "single text chapter_exclude_heading2 AAin",
-        "title": "single header chapter_exclude_heading2 AAin",
+      "location": "chapter_exclude_heading2/index.html#single-header-chapter_exclude_heading2-aain",
+      "text": "single text chapter_exclude_heading2 AAin",
+      "title": "single header chapter_exclude_heading2 AAin"
+    },
+    
+    {
+      "location": "all_dir/all_dir/index.html",
+      "text": "alldir Header all_dir Aex alldir header all_dir AAex alldir text all_dir AAex alldir header all_dir BBex alldir text all_dir BBex",
+      "title": "all_dir"
     },
     {
-        "location": "all_dir/all_dir_ignore_heading1/",
-        "text": "alldir Header all_dir_ignore_heading1 Aex alldir header all_dir_ignore_heading1 AAin alldir text all_dir_ignore_heading1 AAin alldir header all_dir_ignore_heading1 BBex alldir text all_dir_ignore_heading1 BBex",
-        "title": "all_dir_ignore_heading1",
+      "location": "all_dir/all_dir/index.html#alldir-header-all_dir-aex",
+      "text": "",
+      "title": "alldir Header all_dir Aex"
     },
     {
-        "location": "all_dir/all_dir_ignore_heading1/#alldir-header-all_dir_ignore_heading1-aain",
-        "text": "alldir text all_dir_ignore_heading1 AAin",
-        "title": "alldir header all_dir_ignore_heading1 AAin",
+      "location": "all_dir/all_dir/index.html#alldir-header-all_dir-aaex",
+      "text": "alldir text all_dir AAex",
+      "title": "alldir header all_dir AAex"
     },
     {
-        "location": "dir/dir_chapter_ignore_heading3/",
-        "text": "dir single Header dir_chapter_ignore_heading3 Aex dir single header dir_chapter_ignore_heading3 AAex dir single text dir_chapter_ignore_heading3 AAex dir single header dir_chapter_ignore_heading3 CCin dir single text dir_chapter_ignore_heading3 CCin",
-        "title": "dir_chapter_ignore_heading3",
+      "location": "all_dir/all_dir/index.html#alldir-header-all_dir-bbex",
+      "text": "alldir text all_dir BBex",
+      "title": "alldir header all_dir BBex"
     },
     {
-        "location": "dir/dir_chapter_ignore_heading3/#dir-single-header-dir_chapter_ignore_heading3-ccin",
-        "text": "dir single text dir_chapter_ignore_heading3 CCin",
-        "title": "dir single header dir_chapter_ignore_heading3 CCin",
+      "location": "all_dir/all_dir_ignore_heading1/index.html",
+      "text": "alldir Header all_dir_ignore_heading1 Aex alldir header all_dir_ignore_heading1 AAin alldir text all_dir_ignore_heading1 AAin alldir header all_dir_ignore_heading1 BBex alldir text all_dir_ignore_heading1 BBex",
+      "title": "all_dir_ignore_heading1"
+    },
+    {
+      "location": "all_dir/all_dir_ignore_heading1/index.html#alldir-header-all_dir_ignore_heading1-aex",
+      "text": "",
+      "title": "alldir Header all_dir_ignore_heading1 Aex"
+    },
+    {
+      "location": "all_dir/all_dir_ignore_heading1/index.html#alldir-header-all_dir_ignore_heading1-bbex",
+      "text": "alldir text all_dir_ignore_heading1 BBex",
+      "title": "alldir header all_dir_ignore_heading1 BBex"
+    },
+    {
+      "location": "dir/dir_chapter_ignore_heading3/",
+      "text": "dir single Header dir_chapter_ignore_heading3 Aex dir single header dir_chapter_ignore_heading3 AAex dir single text dir_chapter_ignore_heading3 AAex dir single header dir_chapter_ignore_heading3 CCin dir single text dir_chapter_ignore_heading3 CCin",
+      "title": "dir_chapter_ignore_heading3"
+    },
+    {
+      "location": "dir/dir_chapter_ignore_heading3/#dir-single-header-dir_chapter_ignore_heading3-aex",
+      "text": "",
+      "title": "dir single Header dir_chapter_ignore_heading3 Aex"
+    },
+    {
+      "location": "dir/dir_chapter_ignore_heading3/#dir-single-header-dir_chapter_ignore_heading3-aaex",
+      "text": "dir single text dir_chapter_ignore_heading3 AAex",
+      "title": "dir single header dir_chapter_ignore_heading3 AAex"
+    },
+    {
+      "location": "dir/dir_chapter_ignore_heading3/#dir-single-header-dir_chapter_ignore_heading3-ccin",
+      "text": "dir single text dir_chapter_ignore_heading3 CCin",
+      "title": "dir single header dir_chapter_ignore_heading3 CCin"
     },
     {
         "location": "tags.html",

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -18,9 +18,9 @@ TO_EXCLUDE = [
 RESOLVED_EXCLUDED_RECORDS = [
     ["chapter_exclude_all/*", None],
     ["chapter_exclude_heading2/*", "single-header-chapter_exclude_heading2-bbex"],
-    ["dir_chapter_ignore_heading3", None],
-    ["all_dir/*", "alldir-header-all_dir_ignore_heading1-aain"],
-    ["all_dir_sub/all_dir_sub2/*", None],
+    ["dir_chapter_ignore_heading3.html", None],
+    ["all_dir/*.html", "alldir-header-all_dir_ignore_heading1-aain"],
+    ["all_dir_sub/all_dir_sub2/*.html", None],
 ]
 
 TO_IGNORE = [


### PR DESCRIPTION
I am working on a very large mkdocs project and needed to exclude a lot of files from my search index to keep my site responsive. When working with this very helpful plugin I found that I have to exclude every single directory and its children one by one. I found #4 which already asked for an option to recursive exclude files. I've tried to make this change and slightly adapted the notation of exclude rules.