### PR TITLE
Fix to ignore & refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ More information about plugins in the [MkDocs documentation][mkdocs-plugins].
 
 ## Config
 
-- List the markdown files to be excluded under `exclude` using the format `<path>/<to>/filename.md`.
+- List the markdown files to be excluded under `exclude` using the format `<path>/<to>/filename.md` in the docs folder.
 - Exclude specific heading subsections using the format `<path>/<to>/filename.md#some-heading`. Chapter names are all lowercase, `-` as separator, no spaces.
 - Exclude all markdown files within a directory (and its children) with `dirname/*.md` or `dirname/*`.
-- To only include a specific heading subsection of an excluded file, list the subsection under `ignore`. 
+- To still include a subsection of an excluded file, list the subsection heading under `ignore` using the format `<path>/<to>/filename.md#some-heading`. 
 
 ```yaml
 plugins:
@@ -33,7 +33,7 @@ plugins:
       exclude:
         - second.md
         - third.md#some-heading  
-        - dir/*.md  # Only to exclude all files within a directory provide the directory!
+        - dir/*.md
         - dir2/sub/*.md
       ignore:
         - second.md#another-heading
@@ -51,7 +51,7 @@ nav:
 This example would exclude:
 - the second chapter (but still include its `another-heading` subsection) 
 - the `some-heading` subsection of the third chapter.
-- all markdown files within `dir` and `dir2/sub`.
+- all markdown files within `dir` and `dir2/sub` (and their children).
 
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,10 +21,10 @@ plugins:
       exclude:
         - chapter_exclude_all.md
         - chapter_exclude_heading2.md#single-header-chapter_exclude_heading2-bbex # Always a single # for all header levels.
-        - dir_chapter_exclude_all.md
+        - dir/dir_chapter_exclude_all.md
         - dir_chapter_ignore_heading3.md
         - all_dir/*.md
-        - all_dir_sub/all_dir_sub2/*.md
+        - all_dir_sub/all_dir_sub2/*
       ignore:
         - dir_chapter_ignore_heading3.md#dir-single-header-dir_chapter_ignore_heading3-ccin
         - all_dir_ignore_heading1.md#alldir-header-all_dir_ignore_heading1-aain

--- a/mkdocs_exclude_search/plugin.py
+++ b/mkdocs_exclude_search/plugin.py
@@ -80,18 +80,25 @@ class ExcludeSearch(BasePlugin):
     @staticmethod
     def resolve_ignored_chapters(to_ignore: List[str]) -> List[str]:
         """
-        Resolve full search index chapter records from the user provided chapter names
-        (which should be ignored from the exclusion).
+        Supplement the search index main entry for each user provided ignored header.
+
+        In order for a header subchapter to be available in the search index, it requires one
+        "file-name" entry and one "file-name/header-name" entry.
+
+        Args:
+            to_ignore: The user provided list of ignored entries for chapters.
+
+        Returns:
+            A list with each resolved entry as a tuple of (file-name, header-name/None),
+            and with the supplemented main_name entries.
         """
-        ignored_chapters = [f.replace(".md", "") for f in to_ignore if ".md" in f]
-        # Subchapters require both the subchapter as well as the main record to be
-        # included in the search index.
-        ignored_main_records = []
-        for chapter in ignored_chapters:
-            if not chapter.endswith(".md"):
-                ignore_entry_main_name = chapter.split("#")[0]
-                ignored_main_records.append(ignore_entry_main_name)
-        ignored_chapters += ignored_main_records
+        ignored_chapters = [f.replace(".md", ".html") for f in to_ignore]
+        file_name_entries = []
+        for idx, entry in enumerate(ignored_chapters):
+            file_name, header_name = entry.split("#")
+            ignored_chapters[idx] = file_name, header_name
+            file_name_entries.append((file_name, None))
+        ignored_chapters += file_name_entries
         return ignored_chapters
 
     @staticmethod

--- a/mkdocs_exclude_search/plugin.py
+++ b/mkdocs_exclude_search/plugin.py
@@ -137,24 +137,22 @@ class ExcludeSearch(BasePlugin):
                 rec_main_name, rec_chapter_name = record["location"], None
 
             if ExcludeSearch.is_tag_record(record) and exclude_tags:
+                logger.info(f"exclude-search (excludedTags): {record['location']}")
                 continue
             elif "/" not in record["location"]:
-                # index and other neccessary files.
+                logger.debug(f"include-search (requiredRoot): {record['location']}")
                 included_records.append(record)
-                logger.debug(f"include-search (isRoot): {record['location']}")
-            # include record if filename and chapter does not match any rule
-            elif not any(
+            elif any(
                 [
-                    fnmatch(rec_main_name, x[0])
-                    and (
-                        rec_chapter_name == x[1]
-                        or not x[1]
-                    )
-                    for x in to_exclude
+                    fnmatch(rec_file_name, f"*{file_name.replace('.md', '')}?")
+                    and header_name == rec_header_name
+                    for (file_name, header_name) in to_ignore
                 ]
             ):
+                logger.info(f"include-search (ignoredRule): {record['location']}")
+                # e.g. rec_file_name, rec_header_name ('all_dir/all_dir_ignore_heading1/', None) with
+                # to_exclude ('all_dir_ignore_heading1.md', None)
                 included_records.append(record)
-                logger.debug(f"include-search (byRule): {record['location']}")
             else:
                 logger.info(f"exclude-search: {record['location']}")
 

--- a/mkdocs_exclude_search/plugin.py
+++ b/mkdocs_exclude_search/plugin.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 import logging
-from typing import List, Dict
+from typing import List, Dict, Tuple, Union
 from fnmatch import fnmatch
 
 from mkdocs.config import config_options
@@ -54,19 +54,28 @@ class ExcludeSearch(BasePlugin):
             raise ValueError(message)
 
     @staticmethod
-    def resolve_excluded_records(to_exclude: List[str]) -> List[str]:
+    def resolve_excluded_records(
+        to_exclude: List[str],
+    ) -> List[Tuple[str, Union[str, None]]]:
         """
-        Resolve full search index chapter records from the user provided excluded files,
-        chapters and directories ("*").
+        Resolve the search index file-name and header-names from the user provided excluded entries.
+
+        Args:
+            to_exclude: The user provided list of excluded entries for files,
+                headers and directories ("*").
+
+        Returns:
+            A list with each resolved entry as a tuple of (file-name, header-name/None).
         """
-        to_exclude = [f.replace(".md", ".html") for f in to_exclude]
+        excluded_entries = [f.replace(".md", ".html") for f in to_exclude]
         # TODO: This currently could exclude files with an excluded folder of the same name.
-        for idx, entry in enumerate(to_exclude):
+        for idx, entry in enumerate(excluded_entries):
             if "#" in entry:
-                to_exclude[idx] = entry.split("#")
+                file_name, header_name = entry.split("#")
             else:
-                to_exclude[idx] = [entry, None]
-        return to_exclude
+                file_name, header_name = entry, None
+            excluded_entries[idx] = file_name, header_name
+        return excluded_entries
 
     @staticmethod
     def resolve_ignored_chapters(to_ignore: List[str]) -> List[str]:

--- a/tests/mock_data/mock_search_index.json
+++ b/tests/mock_data/mock_search_index.json
@@ -9,119 +9,134 @@
   },
   "docs": [
     {
-      "location": "index.html",
+      "location": "",
       "text": "Index Hello, hello",
       "title": "index"
     },
     {
-      "location": "index.html#index",
+      "location": "#index",
       "text": "Hello, hello",
       "title": "Index"
     },
     {
-      "location": "chapter_exclude_all/exclude.html",
+      "location": "chapter_exclude_all/",
       "text": "Header chapter_exclude_all Aex header chapter_exclude_all AAex text chapter_exclude_all AAex header chapter_exclude_all BBex text chapter_exclude_all BBex",
       "title": "chapter_exclude_all"
     },
     {
-      "location": "chapter_exclude_all/subdir/exclude.html",
-      "text": "Header chapter_exclude_all Aex header chapter_exclude_all AAex text chapter_exclude_all AAex header chapter_exclude_all BBex text chapter_exclude_all BBex in Subdir",
-      "title": "chapter_exclude_all_in_subdir"
-    },
-    {
-      "location": "chapter_exclude_all/index.html#header-chapter_exclude_all-aex",
+      "location": "chapter_exclude_all/#header-chapter_exclude_all-aex",
       "text": "",
       "title": "Header chapter_exclude_all Aex"
     },
     {
-      "location": "chapter_exclude_all/index.html#header-chapter_exclude_all-aaex",
+      "location": "chapter_exclude_all/#header-chapter_exclude_all-aaex",
       "text": "text chapter_exclude_all AAex",
       "title": "header chapter_exclude_all AAex"
     },
     {
-      "location": "chapter_exclude_all/index.html#header-chapter_exclude_all-bbex",
+      "location": "chapter_exclude_all/#header-chapter_exclude_all-bbex",
       "text": "text chapter_exclude_all BBex",
       "title": "header chapter_exclude_all BBex"
     },
     {
-      "location": "chapter_exclude_heading2/index.html",
+      "location": "chapter_exclude_heading2/",
       "text": "single chapter_exclude_heading2 Header Ain single header chapter_exclude_heading2 AAin single text chapter_exclude_heading2 AAin single header chapter_exclude_heading2 BBex single text chapter_exclude_heading2 BBex",
       "title": "chapter_exclude_heading2"
     },
     {
-      "location": "chapter_exclude_heading2/index.html#single-chapter_exclude_heading2-header-ain",
+      "location": "chapter_exclude_heading2/#single-chapter_exclude_heading2-header-ain",
       "text": "",
       "title": "single chapter_exclude_heading2 Header Ain"
     },
     {
-      "location": "chapter_exclude_heading2/index.html#single-header-chapter_exclude_heading2-aain",
+      "location": "chapter_exclude_heading2/#single-header-chapter_exclude_heading2-aain",
       "text": "single text chapter_exclude_heading2 AAin",
       "title": "single header chapter_exclude_heading2 AAin"
     },
     {
-      "location": "chapter_exclude_heading2/index.html#single-header-chapter_exclude_heading2-bbex",
+      "location": "chapter_exclude_heading2/#single-header-chapter_exclude_heading2-bbex",
       "text": "single text chapter_exclude_heading2 BBex",
       "title": "single header chapter_exclude_heading2 BBex"
     },
     {
-      "location": "all_dir/all_dir/index.html",
+      "location": "all_dir/all_dir/",
       "text": "alldir Header all_dir Aex alldir header all_dir AAex alldir text all_dir AAex alldir header all_dir BBex alldir text all_dir BBex",
       "title": "all_dir"
     },
     {
-      "location": "all_dir/all_dir/index.html#alldir-header-all_dir-aex",
+      "location": "all_dir/all_dir/#alldir-header-all_dir-aex",
       "text": "",
       "title": "alldir Header all_dir Aex"
     },
     {
-      "location": "all_dir/all_dir/index.html#alldir-header-all_dir-aaex",
+      "location": "all_dir/all_dir/#alldir-header-all_dir-aaex",
       "text": "alldir text all_dir AAex",
       "title": "alldir header all_dir AAex"
     },
     {
-      "location": "all_dir/all_dir/index.html#alldir-header-all_dir-bbex",
+      "location": "all_dir/all_dir/#alldir-header-all_dir-bbex",
       "text": "alldir text all_dir BBex",
       "title": "alldir header all_dir BBex"
     },
     {
-      "location": "all_dir/all_dir_ignore_heading1/index.html",
+      "location": "all_dir/all_dir_ignore_heading1/",
       "text": "alldir Header all_dir_ignore_heading1 Aex alldir header all_dir_ignore_heading1 AAin alldir text all_dir_ignore_heading1 AAin alldir header all_dir_ignore_heading1 BBex alldir text all_dir_ignore_heading1 BBex",
       "title": "all_dir_ignore_heading1"
     },
     {
-      "location": "all_dir/all_dir_ignore_heading1/index.html#alldir-header-all_dir_ignore_heading1-aex",
+      "location": "all_dir/all_dir_ignore_heading1/#alldir-header-all_dir_ignore_heading1-aex",
       "text": "",
       "title": "alldir Header all_dir_ignore_heading1 Aex"
     },
     {
-      "location": "all_dir/all_dir_ignore_heading1/index.html#alldir-header-all_dir_ignore_heading1-aain",
+      "location": "all_dir/all_dir_ignore_heading1/#alldir-header-all_dir_ignore_heading1-aain",
       "text": "alldir text all_dir_ignore_heading1 AAin",
       "title": "alldir header all_dir_ignore_heading1 AAin"
     },
     {
-      "location": "all_dir/all_dir_ignore_heading1/index.html#alldir-header-all_dir_ignore_heading1-bbex",
+      "location": "all_dir/all_dir_ignore_heading1/#alldir-header-all_dir_ignore_heading1-bbex",
       "text": "alldir text all_dir_ignore_heading1 BBex",
       "title": "alldir header all_dir_ignore_heading1 BBex"
     },
     {
-      "location": "all_dir_sub/all_dir_sub2/all_dir_sub2_1/index.html",
+      "location": "all_dir_sub/all_dir_sub2/all_dir_sub2_1/",
       "text": "alldir Header all_dir_sub2 Aex alldir header all_dir_sub2 AAex alldir text all_dir_sub2 AAex alldir header all_dir_sub2 BBex alldir text all_dir_sub2 BBex",
       "title": "all_dir_sub2"
     },
     {
-      "location": "all_dir_sub/all_dir_sub2/all_dir_sub2_1/index.html#alldir-header-all_dir_sub2-aex",
+      "location": "all_dir_sub/all_dir_sub2/all_dir_sub2_1/#alldir-header-all_dir_sub2-aex",
       "text": "",
       "title": "alldir Header all_dir_sub2 Aex"
     },
     {
-      "location": "all_dir_sub/all_dir_sub2/all_dir_sub2_1/index.html#alldir-header-all_dir_sub2-aaex",
+      "location": "all_dir_sub/all_dir_sub2/all_dir_sub2_1/#alldir-header-all_dir_sub2-aaex",
       "text": "alldir text all_dir_sub2 AAex",
       "title": "alldir header all_dir_sub2 AAex"
     },
     {
-      "location": "all_dir_sub/all_dir_sub2/all_dir_sub2_1/index.html#alldir-header-all_dir_sub2-bbex",
+      "location": "all_dir_sub/all_dir_sub2/all_dir_sub2_1/#alldir-header-all_dir_sub2-bbex",
       "text": "alldir text all_dir_sub2 BBex",
       "title": "alldir header all_dir_sub2 BBex"
+    },
+    {
+      "location": "dir/dir_chapter_exclude_all/",
+      "text": "dir Header dir_chapter_exclude_all Aex dir header dir_chapter_exclude_all AAex dir text dir_chapter_exclude_all AAex dir header dir_chapter_exclude_all BBex dir text dir_chapter_exclude_all BBex",
+      "title": "dir_chapter_exclude_all"
+    },
+    {
+      "location": "dir/dir_chapter_exclude_all/#dir-header-dir_chapter_exclude_all-aex",
+      "text": "",
+      "title": "dir Header dir_chapter_exclude_all Aex"
+    },
+    {
+      "location": "dir/dir_chapter_exclude_all/#dir-header-dir_chapter_exclude_all-aaex",
+      "text": "dir text dir_chapter_exclude_all AAex",
+      "title": "dir header dir_chapter_exclude_all AAex"
+    },
+    {
+      "location": "dir/dir_chapter_exclude_all/#dir-header-dir_chapter_exclude_all-bbex",
+      "text": "dir text dir_chapter_exclude_all BBex",
+      "title": "dir header dir_chapter_exclude_all BBex"
     },
     {
       "location": "dir/dir_chapter_ignore_heading3/",

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -237,19 +237,3 @@ def test_select_records_exclude_tags():
     assert len(included_records) != len(INCLUDED_RECORDS)
     for rec in included_records:
         assert not "tags.html" in rec["location"]
-
-
-# def test_select_records_aa():
-#     _location_ = Path(__file__).resolve().parent
-#     with open(_location_.joinpath("mock_data/mock_search_index.json"), "r") as f:
-#         mock_search_index = json.load(f)
-#
-#     included_records = ExcludeSearch.select_included_records(
-#         search_index=mock_search_index,
-#         to_exclude=RESOLVED_EXCLUDED_RECORDS,
-#         to_ignore=RESOLVED_IGNORED_CHAPTERS,
-#         exclude_tags=EXCLUDE_TAGS,
-#     )
-#     assert isinstance(included_records, list)
-#     assert isinstance(included_records[0], dict)
-#     assert included_records == INCLUDED_RECORDS

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -16,11 +16,12 @@ TO_EXCLUDE = [
 ]
 
 RESOLVED_EXCLUDED_RECORDS = [
-    ["chapter_exclude_all/*", None],
-    ["chapter_exclude_heading2/*", "single-header-chapter_exclude_heading2-bbex"],
-    ["dir_chapter_ignore_heading3.html", None],
-    ["all_dir/*.html", "alldir-header-all_dir_ignore_heading1-aain"],
-    ["all_dir_sub/all_dir_sub2/*.html", None],
+    ("chapter_exclude_all.md", None),
+    ("chapter_exclude_heading2.md", "single-header-chapter_exclude_heading2-bbex"),
+    ("dir_chapter_exclude_all.md", None),
+    ("dir_chapter_ignore_heading3.md", None),
+    ("all_dir/*.md", None),
+    ("all_dir_sub/all_dir_sub2/*.md", None),
 ]
 
 TO_IGNORE = [
@@ -29,10 +30,13 @@ TO_IGNORE = [
 ]
 
 RESOLVED_IGNORED_CHAPTERS = [
-    "dir_chapter_ignore_heading3#dir-single-header-dir_chapter_ignore_heading3-ccin",
-    "all_dir_ignore_heading1#alldir-header-all_dir_ignore_heading1-aain",
-    "dir_chapter_ignore_heading3",
-    "all_dir_ignore_heading1",
+    (
+        "dir_chapter_ignore_heading3.md",
+        "dir-single-header-dir_chapter_ignore_heading3-ccin",
+    ),
+    ("all_dir_ignore_heading1.md", "alldir-header-all_dir_ignore_heading1-aain"),
+    ("dir_chapter_ignore_heading3.md", None),
+    ("all_dir_ignore_heading1.md", None),
 ]
 
 EXCLUDE_TAGS = False

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -8,10 +8,11 @@ from mkdocs_exclude_search.plugin import ExcludeSearch
 
 CONFIG = {"plugins": ["search"]}
 TO_EXCLUDE = [
-    "chapter_exclude_all/*",
-    "chapter_exclude_heading2/*#single-header-chapter_exclude_heading2-bbex",
+    "chapter_exclude_all.md",
+    "chapter_exclude_heading2.md#single-header-chapter_exclude_heading2-bbex",
+    "dir_chapter_exclude_all.md",
     "dir_chapter_ignore_heading3.md",
-    "all_dir/*.md#alldir-header-all_dir_ignore_heading1-aain",
+    "all_dir/*.md",
     "all_dir_sub/all_dir_sub2/*.md",
 ]
 
@@ -42,78 +43,42 @@ RESOLVED_IGNORED_CHAPTERS = [
 EXCLUDE_TAGS = False
 
 INCLUDED_RECORDS = [
-    {"location": "index.html", "text": "Index Hello, hello", "title": "index"},
-    {"location": "index.html#index", "text": "Hello, hello", "title": "Index"},
+    {"location": "", "text": "Index Hello, hello", "title": "index"},
+    {"location": "#index", "text": "Hello, hello", "title": "Index"},
     {
-      "location": "chapter_exclude_heading2/index.html",
-      "text": "single chapter_exclude_heading2 Header Ain single header chapter_exclude_heading2 AAin single text chapter_exclude_heading2 AAin single header chapter_exclude_heading2 BBex single text chapter_exclude_heading2 BBex",
-      "title": "chapter_exclude_heading2"
+        "location": "chapter_exclude_heading2/",
+        "text": "single chapter_exclude_heading2 Header Ain single header chapter_exclude_heading2 AAin single text chapter_exclude_heading2 AAin single header chapter_exclude_heading2 BBex single text chapter_exclude_heading2 BBex",
+        "title": "chapter_exclude_heading2",
     },
     {
-      "location": "chapter_exclude_heading2/index.html#single-chapter_exclude_heading2-header-ain",
-      "text": "",
-      "title": "single chapter_exclude_heading2 Header Ain"
+        "location": "chapter_exclude_heading2/#single-chapter_exclude_heading2-header-ain",
+        "text": "",
+        "title": "single chapter_exclude_heading2 Header Ain",
     },
     {
-      "location": "chapter_exclude_heading2/index.html#single-header-chapter_exclude_heading2-aain",
-      "text": "single text chapter_exclude_heading2 AAin",
-      "title": "single header chapter_exclude_heading2 AAin"
-    },
-    
-    {
-      "location": "all_dir/all_dir/index.html",
-      "text": "alldir Header all_dir Aex alldir header all_dir AAex alldir text all_dir AAex alldir header all_dir BBex alldir text all_dir BBex",
-      "title": "all_dir"
+        "location": "chapter_exclude_heading2/#single-header-chapter_exclude_heading2-aain",
+        "text": "single text chapter_exclude_heading2 AAin",
+        "title": "single header chapter_exclude_heading2 AAin",
     },
     {
-      "location": "all_dir/all_dir/index.html#alldir-header-all_dir-aex",
-      "text": "",
-      "title": "alldir Header all_dir Aex"
+        "location": "all_dir/all_dir_ignore_heading1/",
+        "text": "alldir Header all_dir_ignore_heading1 Aex alldir header all_dir_ignore_heading1 AAin alldir text all_dir_ignore_heading1 AAin alldir header all_dir_ignore_heading1 BBex alldir text all_dir_ignore_heading1 BBex",
+        "title": "all_dir_ignore_heading1",
     },
     {
-      "location": "all_dir/all_dir/index.html#alldir-header-all_dir-aaex",
-      "text": "alldir text all_dir AAex",
-      "title": "alldir header all_dir AAex"
+        "location": "all_dir/all_dir_ignore_heading1/#alldir-header-all_dir_ignore_heading1-aain",
+        "text": "alldir text all_dir_ignore_heading1 AAin",
+        "title": "alldir header all_dir_ignore_heading1 AAin",
     },
     {
-      "location": "all_dir/all_dir/index.html#alldir-header-all_dir-bbex",
-      "text": "alldir text all_dir BBex",
-      "title": "alldir header all_dir BBex"
+        "location": "dir/dir_chapter_ignore_heading3/",
+        "text": "dir single Header dir_chapter_ignore_heading3 Aex dir single header dir_chapter_ignore_heading3 AAex dir single text dir_chapter_ignore_heading3 AAex dir single header dir_chapter_ignore_heading3 CCin dir single text dir_chapter_ignore_heading3 CCin",
+        "title": "dir_chapter_ignore_heading3",
     },
     {
-      "location": "all_dir/all_dir_ignore_heading1/index.html",
-      "text": "alldir Header all_dir_ignore_heading1 Aex alldir header all_dir_ignore_heading1 AAin alldir text all_dir_ignore_heading1 AAin alldir header all_dir_ignore_heading1 BBex alldir text all_dir_ignore_heading1 BBex",
-      "title": "all_dir_ignore_heading1"
-    },
-    {
-      "location": "all_dir/all_dir_ignore_heading1/index.html#alldir-header-all_dir_ignore_heading1-aex",
-      "text": "",
-      "title": "alldir Header all_dir_ignore_heading1 Aex"
-    },
-    {
-      "location": "all_dir/all_dir_ignore_heading1/index.html#alldir-header-all_dir_ignore_heading1-bbex",
-      "text": "alldir text all_dir_ignore_heading1 BBex",
-      "title": "alldir header all_dir_ignore_heading1 BBex"
-    },
-    {
-      "location": "dir/dir_chapter_ignore_heading3/",
-      "text": "dir single Header dir_chapter_ignore_heading3 Aex dir single header dir_chapter_ignore_heading3 AAex dir single text dir_chapter_ignore_heading3 AAex dir single header dir_chapter_ignore_heading3 CCin dir single text dir_chapter_ignore_heading3 CCin",
-      "title": "dir_chapter_ignore_heading3"
-    },
-    {
-      "location": "dir/dir_chapter_ignore_heading3/#dir-single-header-dir_chapter_ignore_heading3-aex",
-      "text": "",
-      "title": "dir single Header dir_chapter_ignore_heading3 Aex"
-    },
-    {
-      "location": "dir/dir_chapter_ignore_heading3/#dir-single-header-dir_chapter_ignore_heading3-aaex",
-      "text": "dir single text dir_chapter_ignore_heading3 AAex",
-      "title": "dir single header dir_chapter_ignore_heading3 AAex"
-    },
-    {
-      "location": "dir/dir_chapter_ignore_heading3/#dir-single-header-dir_chapter_ignore_heading3-ccin",
-      "text": "dir single text dir_chapter_ignore_heading3 CCin",
-      "title": "dir single header dir_chapter_ignore_heading3 CCin"
+        "location": "dir/dir_chapter_ignore_heading3/#dir-single-header-dir_chapter_ignore_heading3-ccin",
+        "text": "dir single text dir_chapter_ignore_heading3 CCin",
+        "title": "dir single header dir_chapter_ignore_heading3 CCin",
     },
     {
         "location": "tags.html",


### PR DESCRIPTION
- Fixes the use of `to_ignored` to ignored specific headings of excluded files.
- Overhauls `resolve_to_ignore` to use the same `file_name`, `header_name` tuple
- Code improvements
- Move conditions for exclude, ignore, tag, root into methods
- Add & Adjusts tests