### PR TITLE
Adjust to ignore directory behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ plugins:
         - dir/*.md
         - dir2/sub/*.md
       ignore:
-        - second.md#another-heading
+        - dir/second.md#some-heading
 
 ```
 ```yaml

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,6 @@ plugins:
         - all_dir/*.md
         - all_dir_sub/all_dir_sub2/*
       ignore:
-        - dir_chapter_ignore_heading3.md#dir-single-header-dir_chapter_ignore_heading3-ccin
-        - all_dir_ignore_heading1.md#alldir-header-all_dir_ignore_heading1-aain
+        - dir/dir_chapter_ignore_heading3.md#dir-single-header-dir_chapter_ignore_heading3-ccin
+        - all_dir/all_dir_ignore_heading1.md#alldir-header-all_dir_ignore_heading1-aain
       #exclude_tags: True   # Default False, only relevant for excluding tags of mkdocs-plugin-tags

--- a/mkdocs_exclude_search/plugin.py
+++ b/mkdocs_exclude_search/plugin.py
@@ -134,7 +134,7 @@ class ExcludeSearch(BasePlugin):
         """
         if any(
             (
-                fnmatch(rec_file_name, f"*{file_name.replace('.md', '')}?")
+                fnmatch(rec_file_name[:-1], f"{file_name.replace('.md', '')}")
                 and header_name == rec_header_name
                 for (file_name, header_name) in to_ignore
             )

--- a/tests/globals.py
+++ b/tests/globals.py
@@ -18,18 +18,21 @@ RESOLVED_EXCLUDED_RECORDS = [
 ]
 
 TO_IGNORE = [
-    "dir_chapter_ignore_heading3.md#dir-single-header-dir_chapter_ignore_heading3-ccin",
-    "all_dir_ignore_heading1.md#alldir-header-all_dir_ignore_heading1-aain",
+    "dir/dir_chapter_ignore_heading3.md#dir-single-header-dir_chapter_ignore_heading3-ccin",
+    "all_dir/all_dir_ignore_heading1.md#alldir-header-all_dir_ignore_heading1-aain",
 ]
 
 RESOLVED_IGNORED_CHAPTERS = [
     (
-        "dir_chapter_ignore_heading3.md",
+        "dir/dir_chapter_ignore_heading3.md",
         "dir-single-header-dir_chapter_ignore_heading3-ccin",
     ),
-    ("all_dir_ignore_heading1.md", "alldir-header-all_dir_ignore_heading1-aain"),
-    ("dir_chapter_ignore_heading3.md", None),
-    ("all_dir_ignore_heading1.md", None),
+    (
+        "all_dir/all_dir_ignore_heading1.md",
+        "alldir-header-all_dir_ignore_heading1-aain",
+    ),
+    ("dir/dir_chapter_ignore_heading3.md", None),
+    ("all_dir/all_dir_ignore_heading1.md", None),
 ]
 
 EXCLUDE_TAGS = False

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -70,24 +70,31 @@ def test_is_root_record():
 def test_is_ignored_record():
     assert ExcludeSearch.is_ignored_record(
         rec_file_name="all_dir/all_dir_ignore_heading1/",
-        rec_header_name=None,
-        to_ignore=[("all_dir_ignore_heading1.md", None)],
+        rec_header_name="alldir-header-all_dir_ignore_heading1-aain",
+        to_ignore=[
+            (
+                "all_dir/all_dir_ignore_heading1.md",
+                "alldir-header-all_dir_ignore_heading1-aain",
+            )
+        ],
     )
-    assert ExcludeSearch.is_ignored_record(
+    # wrong dir specified
+    assert not ExcludeSearch.is_ignored_record(
         rec_file_name="all_dir/all_dir_ignore_heading1/",
         rec_header_name="alldir-header-all_dir_ignore_heading1-aain",
         to_ignore=[
             ("all_dir_ignore_heading1.md", "alldir-header-all_dir_ignore_heading1-aain")
         ],
     )
-
+    # no heading specified
     assert not ExcludeSearch.is_ignored_record(
         rec_file_name="all_dir/all_dir_ignore_heading1/",
         rec_header_name="alldir-header-all_dir_ignore_heading1-aain",
-        to_ignore=[("all_dir_ignore_heading1.md", None)],
+        to_ignore=[("all_dir/all_dir_ignore_heading1.md", None)],
     )
+    # different files
     assert not ExcludeSearch.is_ignored_record(
-        rec_file_name="all_dir/a/", rec_header_name="b", to_ignore=[("c.md", "b")]
+        rec_file_name="a.md", rec_header_name="b", to_ignore=[("c.md", "b")]
     )
 
 
@@ -140,6 +147,14 @@ def test_is_excluded_record():
         rec_header_name="alldir-header-all_dir_sub2-aex",
         to_exclude=[("all_dir_sub/all_dir_sub2/*.md", None)],
     )
+
+
+# def test_is_excluded_record_ignores_partial_filename_matches():
+#     assert not ExcludeSearch.is_excluded_record(
+#         rec_file_name="do_not_match_chapter_exclude_all/",
+#         rec_header_name=None,
+#         to_exclude=[("chapter_exclude_all.md", None)],
+#     )
 
 
 def test_select_records():


### PR DESCRIPTION
to_ignore is required to match exactly to directory paths, user needs to define the directory. No variable directory matching anymore.