### PR TITLE
Adjust to exclude directory behaviour

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,7 @@ test:
 	rm -r .pytest_cache || true
 	black .
 	python -m pytest --pylint --pylint-rcfile=./pylintrc --mypy --mypy-ignore-missing-imports --cov=mkdocs_exclude_search/ --durations=3
-	RET_VALUE=$?
 	coverage-badge -f -o coverage.svg
-	exit $RET_VALUE
 
 serve-python:
 	python /Users/christoph.rieke/.virtualenvs/mkdocs-exclude-search/lib/python3.8/site-packages/mkdocs/__main__.py serve

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ install:
 	pip install -e .
 
 test:
+	rm -r .pytest_cache || true
 	black .
 	python -m pytest --pylint --pylint-rcfile=./pylintrc --mypy --mypy-ignore-missing-imports --cov=mkdocs_exclude_search/ --durations=3
 	RET_VALUE=$?

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ plugins:
         - first.md
         - dir/second.md
         - third.md#some-heading
-        - dir2/*.md
+        - dir2/*
       ignore:
         - dir/second.md#some-heading
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ More information about plugins in the [MkDocs documentation][mkdocs-plugins].
 
 - List the markdown files to be excluded under `exclude` using the format `<path>/<to>/filename.md` in the docs folder.
 - Exclude specific heading subsections using the format `<path>/<to>/filename.md#some-heading`. Chapter names are all lowercase, `-` as separator, no spaces.
-- Exclude all markdown files within a directory (and its children) with `dirname/*.md`.
-- Exclude all markdown files with a specific name within all subdirectories with `dirname//*/filename.md` or `/*/filename.md`.    
+- Exclude all markdown files within a directory (and its children) with `dirname/*`.
+- Exclude all markdown files with a specific name within all subdirectories with `dirname/*/filename.md` or `/*/filename.md`.    
 - To still include a subsection of an excluded file, list the subsection heading under `ignore` using the format `<path>/<to>/filename.md#some-heading`. 
 
 ```yaml
@@ -41,7 +41,7 @@ plugins:
         - dir/second.md
         - third.md#some-heading
         - dir2/*
-        - dir2/*/fifth.md
+        - /*/fifth.md
       ignore:
         - dir/second.md#some-heading
 
@@ -53,7 +53,7 @@ nav:
     - Second chapter: dir/second.md
     - Third chapter: third.md
     - Fourth chapter: dir2/fourth.md
-    - Fifth chapter: dir2/subdir/fifth.md
+    - Fifth chapter: subdir/fifth.md
 ```
 
 This example would exclude:
@@ -61,7 +61,7 @@ This example would exclude:
 - the second chapter (but still include its `some-heading` section).
 - the `some-heading` section of the third chapter.
 - all markdown files within `dir2` (and its children directories).
-- all markdown files named `fifth.md` within all subdirectories of `dir2`.
+- all markdown files named `fifth.md` within all subdirectories.
 
 ## See Also
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ More information about plugins in the [MkDocs documentation][mkdocs-plugins].
 
 - List the markdown files to be excluded under `exclude` using the format `<path>/<to>/filename.md` in the docs folder.
 - Exclude specific heading subsections using the format `<path>/<to>/filename.md#some-heading`. Chapter names are all lowercase, `-` as separator, no spaces.
-- Exclude all markdown files within a directory (and its children) with `dirname/*.md` or `dirname/*`.
+- Exclude all markdown files within a directory (and its children) with `dirname/*.md`.
 - To still include a subsection of an excluded file, list the subsection heading under `ignore` using the format `<path>/<to>/filename.md#some-heading`. 
 
 ```yaml
@@ -36,10 +36,10 @@ plugins:
   - search
   - exclude-search:
       exclude:
-        - second.md
-        - third.md#some-heading  
-        - dir/*.md
-        - dir2/sub/*.md
+        - first.md
+        - dir/second.md
+        - third.md#some-heading
+        - dir2/*.md
       ignore:
         - dir/second.md#some-heading
 
@@ -48,17 +48,20 @@ plugins:
 nav:
     - Home: index.md
     - First chapter: first.md
-    - Second chapter: second.md
+    - Second chapter: dir/second.md
     - Third chapter: third.md
-    - Fourth chapter: some_directory/fourth.md
+    - Fourth chapter: dir2/fourth.md
 ```
 
 This example would exclude:
-- the second chapter (but still include its `another-heading` subsection) 
-- the `some-heading` subsection of the third chapter.
-- all markdown files within `dir` and `dir2/sub` (and their children).
+- the first chapter.
+- the second chapter (but still include its `some-heading` section).
+- the `some-heading` section of the third chapter.
+- all markdown files within `dir2` (and its children directories).
 
-
+Covered cases (TODO):
+- partial matches of filenames
+- multiple files with same name in subdirectories.
 
 ## See Also
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ More information about plugins in the [MkDocs documentation][mkdocs-plugins].
 - List the markdown files to be excluded under `exclude` using the format `<path>/<to>/filename.md` in the docs folder.
 - Exclude specific heading subsections using the format `<path>/<to>/filename.md#some-heading`. Chapter names are all lowercase, `-` as separator, no spaces.
 - Exclude all markdown files within a directory (and its children) with `dirname/*.md`.
+- Exclude all markdown files with a specific name within all subdirectories with `dirname//*/filename.md` or `/*/filename.md`.    
 - To still include a subsection of an excluded file, list the subsection heading under `ignore` using the format `<path>/<to>/filename.md#some-heading`. 
 
 ```yaml
@@ -40,6 +41,7 @@ plugins:
         - dir/second.md
         - third.md#some-heading
         - dir2/*
+        - dir2/*/fifth.md
       ignore:
         - dir/second.md#some-heading
 
@@ -51,6 +53,7 @@ nav:
     - Second chapter: dir/second.md
     - Third chapter: third.md
     - Fourth chapter: dir2/fourth.md
+    - Fifth chapter: dir2/subdir/fifth.md
 ```
 
 This example would exclude:
@@ -58,10 +61,7 @@ This example would exclude:
 - the second chapter (but still include its `some-heading` section).
 - the `some-heading` section of the third chapter.
 - all markdown files within `dir2` (and its children directories).
-
-Covered cases (TODO):
-- partial matches of filenames
-- multiple files with same name in subdirectories.
+- all markdown files named `fifth.md` within all subdirectories of `dir2`.
 
 ## See Also
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,7 +23,7 @@ plugins:
         - chapter_exclude_heading2.md#single-header-chapter_exclude_heading2-bbex # Always a single # for all header levels.
         - dir/dir_chapter_exclude_all.md
         - dir/dir_chapter_ignore_heading3.md
-        - all_dir/*.md
+        - all_dir/*
         - all_dir_sub/all_dir_sub2/*
       ignore:
         - dir/dir_chapter_ignore_heading3.md#dir-single-header-dir_chapter_ignore_heading3-ccin

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,7 +22,7 @@ plugins:
         - chapter_exclude_all.md
         - chapter_exclude_heading2.md#single-header-chapter_exclude_heading2-bbex # Always a single # for all header levels.
         - dir/dir_chapter_exclude_all.md
-        - dir_chapter_ignore_heading3.md
+        - dir/dir_chapter_ignore_heading3.md
         - all_dir/*.md
         - all_dir_sub/all_dir_sub2/*
       ignore:

--- a/mkdocs_exclude_search/plugin.py
+++ b/mkdocs_exclude_search/plugin.py
@@ -160,7 +160,7 @@ class ExcludeSearch(BasePlugin):
         """
         if any(
             (
-                fnmatch(rec_file_name, f"*{file_name.replace('.md', '')}?")
+                fnmatch(rec_file_name[:-1], f"*{file_name.replace('.md', '')}")
                 and (rec_header_name == header_name or not header_name)
                 for (file_name, header_name) in to_exclude
             )

--- a/mkdocs_exclude_search/plugin.py
+++ b/mkdocs_exclude_search/plugin.py
@@ -160,7 +160,7 @@ class ExcludeSearch(BasePlugin):
         """
         if any(
             (
-                fnmatch(rec_file_name[:-1], f"*{file_name.replace('.md', '')}")
+                fnmatch(rec_file_name[:-1], f"{file_name.replace('.md', '')}")
                 and (rec_header_name == header_name or not header_name)
                 for (file_name, header_name) in to_exclude
             )

--- a/tests/globals.py
+++ b/tests/globals.py
@@ -2,8 +2,8 @@ CONFIG = {"plugins": ["search"]}
 TO_EXCLUDE = [
     "chapter_exclude_all.md",
     "chapter_exclude_heading2.md#single-header-chapter_exclude_heading2-bbex",
-    "dir_chapter_exclude_all.md",
-    "dir_chapter_ignore_heading3.md",
+    "dir/dir_chapter_exclude_all.md",
+    "dir/dir_chapter_ignore_heading3.md",
     "all_dir/*.md",
     "all_dir_sub/all_dir_sub2/*.md",
 ]
@@ -11,8 +11,8 @@ TO_EXCLUDE = [
 RESOLVED_EXCLUDED_RECORDS = [
     ("chapter_exclude_all.md", None),
     ("chapter_exclude_heading2.md", "single-header-chapter_exclude_heading2-bbex"),
-    ("dir_chapter_exclude_all.md", None),
-    ("dir_chapter_ignore_heading3.md", None),
+    ("dir/dir_chapter_exclude_all.md", None),
+    ("dir/dir_chapter_ignore_heading3.md", None),
     ("all_dir/*.md", None),
     ("all_dir_sub/all_dir_sub2/*.md", None),
 ]

--- a/tests/globals.py
+++ b/tests/globals.py
@@ -4,8 +4,8 @@ TO_EXCLUDE = [
     "chapter_exclude_heading2.md#single-header-chapter_exclude_heading2-bbex",
     "dir/dir_chapter_exclude_all.md",
     "dir/dir_chapter_ignore_heading3.md",
-    "all_dir/*.md",
-    "all_dir_sub/all_dir_sub2/*.md",
+    "all_dir/*",
+    "all_dir_sub/all_dir_sub2/*",
 ]
 
 RESOLVED_EXCLUDED_RECORDS = [
@@ -13,8 +13,8 @@ RESOLVED_EXCLUDED_RECORDS = [
     ("chapter_exclude_heading2.md", "single-header-chapter_exclude_heading2-bbex"),
     ("dir/dir_chapter_exclude_all.md", None),
     ("dir/dir_chapter_ignore_heading3.md", None),
-    ("all_dir/*.md", None),
-    ("all_dir_sub/all_dir_sub2/*.md", None),
+    ("all_dir/*", None),
+    ("all_dir_sub/all_dir_sub2/*", None),
 ]
 
 TO_IGNORE = [

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -196,8 +196,9 @@ def test_is_not_excluded_record():
         rec_header_name=None,
         to_exclude=[("chapter_exclude_all.md", None)],
     )
+    # partial path match
     assert not ExcludeSearch.is_excluded_record(
-        rec_file_name="do_not_match_chapter_exclude_all/",
+        rec_file_name="all_dir_sub/",
         rec_header_name=None,
         to_exclude=[("all_dir_sub/*/all_dir_sub2_1.md", None)],
     )

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -114,11 +114,17 @@ def test_is_excluded_record():
         rec_header_name=None,
         to_exclude=[("chapter_exclude_all.md", "something.md")],
     )
-    # file + header
+    # file + header (not specifically excluded)
     assert ExcludeSearch.is_excluded_record(
         rec_file_name="chapter_exclude_all/",
         rec_header_name="header-chapter_exclude_all-aex",
         to_exclude=[("chapter_exclude_all.md", None)],
+    )
+    # file + header (specifically excluded)
+    assert ExcludeSearch.is_excluded_record(
+        rec_file_name="chapter_exclude_all/",
+        rec_header_name="header-chapter_exclude_all-aex",
+        to_exclude=[("chapter_exclude_all.md", "header-chapter_exclude_all-aex")],
     )
     # file in dir
     assert ExcludeSearch.is_excluded_record(
@@ -155,6 +161,26 @@ def test_is_excluded_record():
         rec_header_name="alldir-header-all_dir_sub2-aex",
         to_exclude=[("all_dir_sub/all_dir_sub2/*", None)],
     )
+    # file within subdir wildcard
+    assert ExcludeSearch.is_excluded_record(
+        rec_file_name="all_dir_sub/all_dir_sub2/all_dir_sub2_1/",
+        rec_header_name=None,
+        to_exclude=[("all_dir_sub/*/all_dir_sub2_1.md", None)],
+    )
+    # file within multiple subdir wildcard
+    assert ExcludeSearch.is_excluded_record(
+        rec_file_name="all_dir_sub/all_dir_sub2/all_dir_sub2_again/all_dir_sub2_1/",
+        rec_header_name=None,
+        to_exclude=[("all_dir_sub/*/all_dir_sub2_1.md", None)],
+    )
+    # file within multiple subdir wildcard + header
+    assert ExcludeSearch.is_excluded_record(
+        rec_file_name="all_dir_sub/all_dir_sub2/all_dir_sub2_again/all_dir_sub2_1/",
+        rec_header_name="alldir-header-all_dir_sub2-aex",
+        to_exclude=[
+            ("all_dir_sub/*/all_dir_sub2_1.md", "alldir-header-all_dir_sub2-aex")
+        ],
+    )
 
 
 def test_is_not_excluded_record():
@@ -164,11 +190,16 @@ def test_is_not_excluded_record():
         rec_header_name=None,
         to_exclude=[("dir_chapter_exclude_all.md", None)],
     )
-    # ignores partial filename matches
+    # partial filename matches
     assert not ExcludeSearch.is_excluded_record(
         rec_file_name="do_not_match_chapter_exclude_all/",
         rec_header_name=None,
         to_exclude=[("chapter_exclude_all.md", None)],
+    )
+    assert not ExcludeSearch.is_excluded_record(
+        rec_file_name="do_not_match_chapter_exclude_all/",
+        rec_header_name=None,
+        to_exclude=[("all_dir_sub/*/all_dir_sub2_1.md", None)],
     )
 
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -78,6 +78,9 @@ def test_is_ignored_record():
             )
         ],
     )
+
+
+def test_is_not_ignored_record():
     # wrong dir specified
     assert not ExcludeSearch.is_ignored_record(
         rec_file_name="all_dir/all_dir_ignore_heading1/",
@@ -123,38 +126,50 @@ def test_is_excluded_record():
         rec_header_name=None,
         to_exclude=[("dir/dir_chapter_exclude_all.md", None)],
     )
-    # dir
+    # all dir
     assert ExcludeSearch.is_excluded_record(
         rec_file_name="all_dir/some-chapter/",
         rec_header_name=None,
-        to_exclude=[("all_dir/*.md", None)],
+        to_exclude=[("all_dir/*", None)],
     )
-    # dir + header
+    assert ExcludeSearch.is_excluded_record(
+        rec_file_name="all_dir/some-chapter/",
+        rec_header_name=None,
+        to_exclude=[("all_dir/*", None)],
+    )
+    # all dir + header
     assert ExcludeSearch.is_excluded_record(
         rec_file_name="all_dir/some-chapter/",
         rec_header_name="all_dir/some-chapter-aex",
-        to_exclude=[("all_dir/*.md", None)],
+        to_exclude=[("all_dir/*", None)],
     )
-    # subdir
+    # all subdir
     assert ExcludeSearch.is_excluded_record(
         rec_file_name="all_dir_sub/all_dir_sub2/some-chapter/",
         rec_header_name=None,
-        to_exclude=[("all_dir_sub/all_dir_sub2/*.md", None)],
+        to_exclude=[("all_dir_sub/all_dir_sub2/*", None)],
     )
-    # subdir + header
+    # all subdir + header
     assert ExcludeSearch.is_excluded_record(
         rec_file_name="all_dir_sub/all_dir_sub2/some-chapter/",
         rec_header_name="alldir-header-all_dir_sub2-aex",
-        to_exclude=[("all_dir_sub/all_dir_sub2/*.md", None)],
+        to_exclude=[("all_dir_sub/all_dir_sub2/*", None)],
     )
 
 
-# def test_is_excluded_record_ignores_partial_filename_matches():
-#     assert not ExcludeSearch.is_excluded_record(
-#         rec_file_name="do_not_match_chapter_exclude_all/",
-#         rec_header_name=None,
-#         to_exclude=[("chapter_exclude_all.md", None)],
-#     )
+def test_is_not_excluded_record():
+    # file in dir without dir specified
+    assert not ExcludeSearch.is_excluded_record(
+        rec_file_name="dir/dir_chapter_exclude_all/",
+        rec_header_name=None,
+        to_exclude=[("dir_chapter_exclude_all.md", None)],
+    )
+    # ignores partial filename matches
+    assert not ExcludeSearch.is_excluded_record(
+        rec_file_name="do_not_match_chapter_exclude_all/",
+        rec_header_name=None,
+        to_exclude=[("chapter_exclude_all.md", None)],
+    )
 
 
 def test_select_records():


### PR DESCRIPTION
Adjusts to_exclude behaviour to:
- no more wildcard directory matching by default. A md file within a directory needs to be explicitly listed as `dir/filename.md`.
- Clarify wildcard matching behaviour for all .md files within a directory in readme and examples
- Document wildcard matching for subdirectories.

Also see clarified instructions in readme.md covering all available cases.

