### PR TITLE
Change excluded entries to only be logged in debug mode

### DIFF
--- a/mkdocs_exclude_search/plugin.py
+++ b/mkdocs_exclude_search/plugin.py
@@ -195,16 +195,16 @@ class ExcludeSearch(BasePlugin):
 
             # pylint: disable=no-else-continue
             if self.is_tag_record(rec_file_name) and exclude_tags:
-                logger.info(f"exclude-search (excludedTags): {record['location']}")
+                logger.debug(f"exclude-search (excludedTags): {record['location']}")
                 continue
             elif self.is_root_record(rec_file_name):
                 logger.debug(f"include-search (requiredRoot): {record['location']}")
                 included_records.append(record)
             elif self.is_ignored_record(rec_file_name, rec_header_name, to_ignore):
-                logger.info(f"include-search (ignoredRule): {record['location']}")
+                logger.debug(f"include-search (ignoredRule): {record['location']}")
                 included_records.append(record)
             elif self.is_excluded_record(rec_file_name, rec_header_name, to_exclude):
-                logger.info(f"exclude-search (excludedRule): {record['location']}")
+                logger.debug(f"exclude-search (excludedRule): {record['location']}")
                 continue
             else:
                 logger.debug(f"include-search (noRule): {record['location']}")


### PR DESCRIPTION
The classification of the logs at INFO level resulted in the list of exlusions to always be shown in logs. This adds a lot of noise to the output of a ci setup with many (excluded) pages.

As such, the possibility to limit the output from this plugin would be helpful.

08561b1 removes the logs for exclusions by default. 
The logs can still be displayed in debug mode by using the -v options with mkdocs serve.