### PR TITLE
add single logger info message for user feedback

### DIFF
--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">83%</text>
-        <text x="80" y="14">83%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">82%</text>
+        <text x="80" y="14">82%</text>
     </g>
 </svg>

--- a/mkdocs_exclude_search/plugin.py
+++ b/mkdocs_exclude_search/plugin.py
@@ -239,6 +239,12 @@ class ExcludeSearch(BasePlugin):
             exclude_tags=exclude_tags,
         )
 
+        logger.info(
+            f"mkdocs-exclude-search excluded {len(search_index['docs']) - len(included_records)}"
+            f" of {len(search_index['docs'])} search index records. Use `mkdocs serve -v` "
+            f"for more details."
+        )
+
         search_index["docs"] = included_records
         with open(search_index_fp, "w") as f:
             json.dump(search_index, f)


### PR DESCRIPTION
The detailed logger for each search index entry are only available in verbose output https://github.com/chrieke/mkdocs-exclude-search/pull/14, but since the configuration and success feedback of this plugin is not trivial would be good to give a single logger.info user feedback.