### PR TITLE
Exclude unreferenced files

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ plugins:
         - /*/fifth.md
       ignore:
         - dir/second.md#some-heading
+      exclude-unreferenced: true
 
 ```
 ```yaml

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ More information about plugins in the [MkDocs documentation][mkdocs-plugins].
 - Exclude all markdown files within a directory (and its children) with `dirname/*`.
 - Exclude all markdown files with a specific name within all subdirectories with `dirname/*/filename.md` or `/*/filename.md`.    
 - To still include a subsection of an excluded file, list the subsection heading under `ignore` using the format `<path>/<to>/filename.md#some-heading`. 
+- To exclude all unreferenced files (markdown files not listed in mkdocs.yml nav section), use `exclude-unreferenced: true`. Default false.
 
 ```yaml
 plugins:
@@ -63,6 +64,7 @@ This example would exclude:
 - the `some-heading` section of the third chapter.
 - all markdown files within `dir2` (and its children directories).
 - all markdown files named `fifth.md` within all subdirectories.
+- all unreferenced files
 
 ## See Also
 

--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">84%</text>
-        <text x="80" y="14">84%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">83%</text>
+        <text x="80" y="14">83%</text>
     </g>
 </svg>

--- a/docs/unreferenced.md
+++ b/docs/unreferenced.md
@@ -1,0 +1,7 @@
+# unreferenced file heading1 Aex
+
+This is an example of an unreferenced file
+
+## Unreferenced file heading2 AAex
+
+## Unreferenced file heading2 BBex

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,7 +10,6 @@ nav:
     - all_dir_ignore_heading1: all_dir/all_dir_ignore_heading1.md
     - all_dir_sub2: all_dir_sub/all_dir_sub2/all_dir_sub2_1.md
 
-
 theme:
   name: material
 
@@ -28,4 +27,5 @@ plugins:
       ignore:
         - dir/dir_chapter_ignore_heading3.md#dir-single-header-dir_chapter_ignore_heading3-ccin
         - all_dir/all_dir_ignore_heading1.md#alldir-header-all_dir_ignore_heading1-aain
+      exclude_unreferenced: true
       #exclude_tags: True   # Default False, only relevant for excluding tags of mkdocs-plugin-tags

--- a/mkdocs_exclude_search/plugin.py
+++ b/mkdocs_exclude_search/plugin.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 import logging
-from typing import List, Dict, Tuple, Union, Any, Optional
+from typing import List, Dict, Tuple, Union, Any
 from fnmatch import fnmatch
 
 from mkdocs.config import config_options
@@ -107,14 +107,12 @@ class ExcludeSearch(BasePlugin):
         return ignored_chapters
 
     @staticmethod
-    def is_unreferenced_record(
-        rec_file_name: str, navigation_items: Optional[List[str]]
-    ):
-        """Tags entries of mkdocs-plugin-tags"""
-        if navigation_items is None:
-            return False
-        else:
-            return rec_file_name not in navigation_items
+    def is_unreferenced_record(rec_file_name: str, navigation_items: List[str]):
+        """
+        Unreferenced markdown files that are not contained in mkdocs.yml navigation
+        nav section.
+        """
+        return rec_file_name not in navigation_items
 
     @staticmethod
     def is_tag_record(rec_file_name: str):
@@ -187,8 +185,8 @@ class ExcludeSearch(BasePlugin):
         search_index: Dict,
         to_exclude: List[Tuple[Any, ...]],
         to_ignore: List[Tuple[Any, ...]],
+        navigation_items: List[str],
         exclude_unreferenced: bool = False,
-        navigation_items: Optional[List[str]] = None,
         exclude_tags: bool = False,
     ) -> List[Dict]:
         """
@@ -198,9 +196,10 @@ class ExcludeSearch(BasePlugin):
             search_index: The mkdocs search index in "config.data["site_dir"]) / "search/search_index.json"
             to_exclude: Resolved list of excluded search index records.
             to_ignore: Resolved list of ignored search index chapter records.
+            navigation_items: List of markdown filepaths in the mkdocs.yml nav, in the format
+                ["filename/", dir/filename/]
             exclude_unreferenced: Boolean wether unreferenced files (not listed in mkdocs nav)
                 should be excluded, default False.
-            navigation_items: List of markdown filepaths in the mkdocs.yml nav
             exclude_tags: Boolean wether mkdocs-plugin-tags entries should be excluded, default False.
 
         Returns:
@@ -254,19 +253,17 @@ class ExcludeSearch(BasePlugin):
         to_ignore = None
         if self.config["ignore"]:
             to_ignore = self.resolve_ignored_chapters(to_ignore=self.config["ignore"])
-        navigation_items = None
-        if self.config["exclude_unreferenced"]:
-            navigation_items = [
-                list(nav_chapter.values())[0].replace(".md", "/")
-                for nav_chapter in config.data["nav"]
-            ]
+        navigation_items = [
+            list(nav_chapter.values())[0].replace(".md", "/")
+            for nav_chapter in config.data["nav"]
+        ]
 
         included_records = self.select_included_records(
             search_index=search_index,
             to_exclude=to_exclude,
             to_ignore=to_ignore,
-            exclude_unreferenced=self.config["exclude_unreferenced"],
             navigation_items=navigation_items,
+            exclude_unreferenced=self.config["exclude_unreferenced"],
             exclude_tags=self.config["exclude_tags"],
         )
 

--- a/mkdocs_exclude_search/plugin.py
+++ b/mkdocs_exclude_search/plugin.py
@@ -37,11 +37,11 @@ class ExcludeSearch(BasePlugin):
         self.enabled = True
         self.total_time = 0
 
-    def check_config(self):
+    def check_config(self, plugins: List[str]):
         """
         Check plugin configuration.
         """
-        if not "search" in self.config["plugins"]:
+        if not "search" in plugins:
             message = (
                 "mkdocs-exclude-search plugin is activated but has no effect as "
                 "search plugin is deactivated!"
@@ -237,8 +237,9 @@ class ExcludeSearch(BasePlugin):
         return included_records
 
     def on_post_build(self, config):
+        # at mkdocs buildtime, self.config does not contain the same as config
         try:
-            self.check_config()
+            self.check_config(plugins=config["plugins"])
         except ValueError:
             return config
 

--- a/mkdocs_exclude_search/plugin.py
+++ b/mkdocs_exclude_search/plugin.py
@@ -114,7 +114,7 @@ class ExcludeSearch(BasePlugin):
         if navigation_items is None:
             return False
         else:
-            return rec_file_name in navigation_items
+            return rec_file_name not in navigation_items
 
     @staticmethod
     def is_tag_record(rec_file_name: str):
@@ -250,23 +250,24 @@ class ExcludeSearch(BasePlugin):
         with open(search_index_fp, "r") as f:
             search_index = json.load(f)
 
-        to_exclude = self.resolve_excluded_records(to_exclude=config["exclude"])
+        to_exclude = self.resolve_excluded_records(to_exclude=self.config["exclude"])
         to_ignore = None
-        if config["ignore"]:
-            to_ignore = self.resolve_ignored_chapters(to_ignore=config["ignore"])
+        if self.config["ignore"]:
+            to_ignore = self.resolve_ignored_chapters(to_ignore=self.config["ignore"])
         navigation_items = None
-        if config["exclude_unreferenced"]:
+        if self.config["exclude_unreferenced"]:
             navigation_items = [
-                list(nav_chapter.values())[0] for nav_chapter in config.data["nav"]
+                list(nav_chapter.values())[0].replace(".md", "/")
+                for nav_chapter in config.data["nav"]
             ]
 
         included_records = self.select_included_records(
             search_index=search_index,
             to_exclude=to_exclude,
             to_ignore=to_ignore,
-            exclude_unreferenced=config["exclude_unreferenced"],
+            exclude_unreferenced=self.config["exclude_unreferenced"],
             navigation_items=navigation_items,
-            exclude_tags=config["exclude_tags"],
+            exclude_tags=self.config["exclude_tags"],
         )
 
         logger.info(

--- a/mkdocs_exclude_search/plugin.py
+++ b/mkdocs_exclude_search/plugin.py
@@ -124,7 +124,10 @@ class ExcludeSearch(BasePlugin):
 
     @staticmethod
     def is_root_record(rec_file_name: str):
-        """Required mkdocs root files"""
+        """Required mkdocs root files.
+
+        Collides with is_tag_record as these have no slash. Handled by order in select_included_records.
+        """
         return "/" not in rec_file_name
 
     @staticmethod
@@ -214,6 +217,9 @@ class ExcludeSearch(BasePlugin):
             if exclude_tags and self.is_tag_record(rec_file_name):
                 logger.debug(f"exclude-search (excludedTags): {record['location']}")
                 continue
+            elif self.is_root_record(rec_file_name):
+                logger.debug(f"include-search (requiredRoot): {record['location']}")
+                included_records.append(record)
             elif exclude_unreferenced and self.is_unreferenced_record(
                 rec_file_name=rec_file_name, navigation_items=navigation_items
             ):
@@ -221,9 +227,6 @@ class ExcludeSearch(BasePlugin):
                     f"exclude-search (excludedUnreferenced): {record['location']}"
                 )
                 continue
-            elif self.is_root_record(rec_file_name):
-                logger.debug(f"include-search (requiredRoot): {record['location']}")
-                included_records.append(record)
             elif self.is_ignored_record(rec_file_name, rec_header_name, to_ignore):
                 logger.debug(f"include-search (ignoredRule): {record['location']}")
                 included_records.append(record)

--- a/mkdocs_exclude_search/plugin.py
+++ b/mkdocs_exclude_search/plugin.py
@@ -49,7 +49,7 @@ class ExcludeSearch(BasePlugin):
             logger.debug(message)
             raise ValueError(message)
         if (
-            not self.config["to_exclude"]
+            not self.config["exclude"]
             and not self.config["exclude_unreferenced"]
             and not self.config["exclude_tags"]
         ):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -16,7 +16,7 @@ from .globals import (
 
 
 @pytest.mark.parametrize(
-    "to_exclude,exclude_unreferenced,exclude_tags",
+    "exclude,exclude_unreferenced,exclude_tags",
     [
         (TO_EXCLUDE, EXCLUDE_UNREFERENCED, EXCLUDE_TAGS),
         (TO_EXCLUDE, True, True),
@@ -25,11 +25,11 @@ from .globals import (
         ([], True, True),
     ],
 )
-def test_check_config(to_exclude, exclude_unreferenced, exclude_tags):
+def test_check_config(exclude, exclude_unreferenced, exclude_tags):
     ex = ExcludeSearch()
     ex.config = dict(
         {
-            "to_exclude": to_exclude,
+            "exclude": exclude,
             "exclude_unreferenced": exclude_unreferenced,
             "exclude_tags": exclude_tags,
         }
@@ -47,7 +47,7 @@ def test_check_config_raises_no_exclusion():
     ex = ExcludeSearch()
     ex.config = dict(
         {
-            "to_exclude": [],
+            "exclude": [],
             "exclude_unreferenced": EXCLUDE_UNREFERENCED,
             "exclude_tags": EXCLUDE_TAGS,
         }

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -249,6 +249,7 @@ def test_select_records():
         search_index=mock_search_index,
         to_exclude=RESOLVED_EXCLUDED_RECORDS,
         to_ignore=RESOLVED_IGNORED_CHAPTERS,
+        navigation_items=[],
         exclude_tags=EXCLUDE_TAGS,
     )
     assert isinstance(included_records, list)
@@ -265,8 +266,8 @@ def test_select_records_unreferenced():
         search_index=mock_search_index,
         to_exclude=[],
         to_ignore=[],
-        exclude_unreferenced=True,
         navigation_items=["chapter_exclude_all/"],
+        exclude_unreferenced=True,
     )
     assert isinstance(included_records, list)
     assert isinstance(included_records[0], dict)
@@ -283,6 +284,7 @@ def test_select_records_exclude_tags():
         search_index=mock_search_index,
         to_exclude=RESOLVED_EXCLUDED_RECORDS,
         to_ignore=RESOLVED_IGNORED_CHAPTERS,
+        navigation_items=[],
         exclude_tags=True,
     )
     assert len(included_records) != len(INCLUDED_RECORDS)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -29,41 +29,31 @@ def test_check_config(to_exclude, exclude_unreferenced, exclude_tags):
     ex = ExcludeSearch()
     ex.config = dict(
         {
-            "plugins": ["search"],
             "to_exclude": to_exclude,
             "exclude_unreferenced": exclude_unreferenced,
             "exclude_tags": exclude_tags,
         }
     )
-    ex.check_config()
+    ex.check_config(plugins=["search"])
 
 
 def test_check_config_raises_search_deactivated():
     ex = ExcludeSearch()
-    ex.config = dict(
-        {
-            "plugins": ["abc"],
-            "to_exclude": TO_EXCLUDE,
-            "exclude_unreferenced": EXCLUDE_UNREFERENCED,
-            "exclude_tags": EXCLUDE_TAGS,
-        }
-    )
     with pytest.raises(ValueError):
-        ex.check_config()
+        ex.check_config(plugins=["abc"])
 
 
 def test_check_config_raises_no_exclusion():
     ex = ExcludeSearch()
     ex.config = dict(
         {
-            "plugins": ["search"],
             "to_exclude": [],
             "exclude_unreferenced": EXCLUDE_UNREFERENCED,
             "exclude_tags": EXCLUDE_TAGS,
         }
     )
     with pytest.raises(ValueError):
-        ex.check_config()
+        ex.check_config(plugins=["search"])
 
 
 def test_resolve_excluded_records():

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -206,6 +206,19 @@ def test_is_excluded_record_wildcard():
     )
 
 
+def test_is_unreferenced_record_unreferenced():
+    # unreferenced file, not listed in mkdocs.yml nav
+    assert ExcludeSearch.is_unreferenced_record(
+        rec_file_name="unreferenced/",
+        navigation_items=["index/", "chapter_exclude_all/"],
+    )
+
+    assert not ExcludeSearch.is_unreferenced_record(
+        rec_file_name="chapter_exclude_all/",
+        navigation_items=["index/", "chapter_exclude_all/"],
+    )
+
+
 def test_is_not_excluded_record():
     # file in dir without dir specified
     assert not ExcludeSearch.is_excluded_record(
@@ -241,6 +254,24 @@ def test_select_records():
     assert isinstance(included_records, list)
     assert isinstance(included_records[0], dict)
     assert included_records == INCLUDED_RECORDS
+
+
+def test_select_records_unreferenced():
+    _location_ = Path(__file__).resolve().parent
+    with open(_location_.joinpath("mock_data/mock_search_index.json"), "r") as f:
+        mock_search_index = json.load(f)
+
+    included_records = ExcludeSearch().select_included_records(
+        search_index=mock_search_index,
+        to_exclude=[],
+        to_ignore=[],
+        exclude_unreferenced=True,
+        navigation_items=["chapter_exclude_all/"],
+    )
+    assert isinstance(included_records, list)
+    assert isinstance(included_records[0], dict)
+    assert included_records != INCLUDED_RECORDS
+    assert len(included_records) == 10
 
 
 def test_select_records_exclude_tags():


### PR DESCRIPTION
Option to exclude unreferenced files as in https://github.com/chrieke/mkdocs-exclude-search/issues/17

mkdocs builds includes all markdown files in the build, regardless if they are actually referenced in the mkdocs.yml navigation menu. These pages can still be accessed in the docs via direct link, and their content can also be found via search.

This `exclude_unreferenced` option allows to exclude the contents of all unreferenced filed from the search results. It can currently not be combined with the `ignore` feature, the full page content will be ignored.