### PR TITLE
Fix multiple subchapters

### DIFF
--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">83%</text>
-        <text x="80" y="14">83%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">86%</text>
+        <text x="80" y="14">86%</text>
     </g>
 </svg>

--- a/docs/toplvl_chapter/file_in_toplvl_chapter.md
+++ b/docs/toplvl_chapter/file_in_toplvl_chapter.md
@@ -1,0 +1,3 @@
+# Header file_in_toplvl_chapter
+
+text file_in_toplvl_chapter

--- a/docs/toplvl_chapter/sub_chapter/file1_in_sub_chapter.md
+++ b/docs/toplvl_chapter/sub_chapter/file1_in_sub_chapter.md
@@ -1,0 +1,3 @@
+# Header file1_in_sub_chapter
+
+text file1_in_sub_chapter

--- a/docs/toplvl_chapter/sub_chapter/file2_in_sub_chapter.md
+++ b/docs/toplvl_chapter/sub_chapter/file2_in_sub_chapter.md
@@ -1,0 +1,3 @@
+# Header file2_in_sub_chapter
+
+text file2_in_sub_chapter

--- a/docs/toplvl_chapter/sub_chapter/unreferenced_in_sub_chapter.md
+++ b/docs/toplvl_chapter/sub_chapter/unreferenced_in_sub_chapter.md
@@ -1,0 +1,3 @@
+# Header unreferenced_in_sub_chapter
+
+text unreferenced_in_sub_chapter

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,10 @@ nav:
     - all_dir: all_dir/all_dir.md
     - all_dir_ignore_heading1: all_dir/all_dir_ignore_heading1.md
     - all_dir_sub2: all_dir_sub/all_dir_sub2/all_dir_sub2_1.md
+    - toplvl_chapter:
+        - sub_chapter:
+            - toplvl_chapter/sub_chapter/file1_in_sub_chapter.md
+            - toplvl_chapter/sub_chapter/file2_in_sub_chapter.md
 
 theme:
   name: material

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
     - all_dir_ignore_heading1: all_dir/all_dir_ignore_heading1.md
     - all_dir_sub2: all_dir_sub/all_dir_sub2/all_dir_sub2_1.md
     - toplvl_chapter:
+        - toplvl_chapter/file_in_toplvl_chapter.md
         - sub_chapter:
             - toplvl_chapter/sub_chapter/file1_in_sub_chapter.md
             - toplvl_chapter/sub_chapter/file2_in_sub_chapter.md

--- a/mkdocs_exclude_search/plugin.py
+++ b/mkdocs_exclude_search/plugin.py
@@ -58,6 +58,31 @@ class ExcludeSearch(BasePlugin):
             raise ValueError(message)
 
     @staticmethod
+    def explode_navigation(navigation: List[dict]) -> List[str]:
+        """
+        Explode the mkdocs.yml navigation items.
+        Args:
+            navigation:
+
+        Returns:
+
+        """
+        navigation_paths = []
+        # for nav_item in navigation:
+        #     chapters = list(nav_item.values())
+        #     while chapters > 1:
+        #
+        #     else:
+        #         navigation_paths.append(chapters[0])
+        #
+        # navigation_items = [
+        #     list(nav_chapter.values())[0].replace(".md", "/")
+        #     for nav_chapter in
+        #
+
+        return navigation_paths
+
+    @staticmethod
     def resolve_excluded_records(
         to_exclude: List[str],
     ) -> List:
@@ -253,10 +278,8 @@ class ExcludeSearch(BasePlugin):
         to_ignore = None
         if self.config["ignore"]:
             to_ignore = self.resolve_ignored_chapters(to_ignore=self.config["ignore"])
-        navigation_items = [
-            list(nav_chapter.values())[0].replace(".md", "/")
-            for nav_chapter in config.data["nav"]
-        ]
+
+        navigation_items = self.explode_navigation(navigation=config.data["nav"])
 
         included_records = self.select_included_records(
             search_index=search_index,

--- a/mkdocs_exclude_search/plugin.py
+++ b/mkdocs_exclude_search/plugin.py
@@ -8,13 +8,10 @@ from mkdocs.config import config_options
 from mkdocs.plugins import BasePlugin
 from mkdocs.utils import warning_filter
 
-from utils import explode_navigation
+from mkdocs_exclude_search.utils import explode_navigation
 
 
 def get_logger():
-    """
-    Return a pre-configured logger.
-    """
     logger = logging.getLogger("mkdocs.plugins.mkdocs-exclude-search")
     logger.addFilter(warning_filter)
     return logger
@@ -25,7 +22,7 @@ logger = get_logger()
 
 class ExcludeSearch(BasePlugin):
     """
-    Excludes selected nav chapters from the search index.
+    Excludes selected files, nav chapters and headers from the search index.
     """
 
     config_scheme = (

--- a/mkdocs_exclude_search/plugin.py
+++ b/mkdocs_exclude_search/plugin.py
@@ -8,6 +8,8 @@ from mkdocs.config import config_options
 from mkdocs.plugins import BasePlugin
 from mkdocs.utils import warning_filter
 
+from utils import explode_navigation
+
 
 def get_logger():
     """
@@ -56,31 +58,6 @@ class ExcludeSearch(BasePlugin):
             message = "No excluded search entries selected for mkdocs-exclude-search."
             logger.info(message)
             raise ValueError(message)
-
-    @staticmethod
-    def explode_navigation(navigation: List[dict]) -> List[str]:
-        """
-        Explode the mkdocs.yml navigation items.
-        Args:
-            navigation:
-
-        Returns:
-
-        """
-        navigation_paths = []
-        # for nav_item in navigation:
-        #     chapters = list(nav_item.values())
-        #     while chapters > 1:
-        #
-        #     else:
-        #         navigation_paths.append(chapters[0])
-        #
-        # navigation_items = [
-        #     list(nav_chapter.values())[0].replace(".md", "/")
-        #     for nav_chapter in
-        #
-
-        return navigation_paths
 
     @staticmethod
     def resolve_excluded_records(
@@ -279,7 +256,7 @@ class ExcludeSearch(BasePlugin):
         if self.config["ignore"]:
             to_ignore = self.resolve_ignored_chapters(to_ignore=self.config["ignore"])
 
-        navigation_items = self.explode_navigation(navigation=config.data["nav"])
+        navigation_items = explode_navigation(navigation=config.data["nav"])
 
         included_records = self.select_included_records(
             search_index=search_index,

--- a/mkdocs_exclude_search/utils.py
+++ b/mkdocs_exclude_search/utils.py
@@ -1,0 +1,37 @@
+def iterate_all_values(nested_dict: dict):
+    """
+    Returns an iterator that returns all values of a (nested) iterable of the form
+    {'a': ['aa', {'b': ['cc', {'d': ['ee', 'ff', {'d': ['gg', 'hh']}]}]}]}
+
+    Inspired by https://gist.github.com/PatrikHlobil/9d045e43fe44df2d5fd8b570f9fd78cc
+    """
+    if isinstance(nested_dict, dict):
+        for value in nested_dict.values():
+            if not isinstance(value, (dict, list)):
+                yield value
+            for ret in iterate_all_values(value):
+                yield ret
+    elif isinstance(nested_dict, list):
+        for el in nested_dict:
+            for ret in iterate_all_values(el):
+                yield ret
+    elif isinstance(nested_dict, str):
+        yield nested_dict
+
+
+def explode_navigation(navigation: list):
+    # Paths to chapters in mkdocs.yml navigation section to compare
+    # with unreferenced files.
+    navigation_paths = []
+
+    for chapter in navigation:
+        chapter_paths = list(chapter.values())[0]
+        if isinstance(chapter_paths, str):
+            navigation_paths.append(chapter_paths)
+        elif isinstance(chapter_paths, list):
+            exploded_chapter_paths = iterate_all_values(nested_dict=chapter)
+            navigation_paths.extend(exploded_chapter_paths)
+
+    navigation_paths = [nav_path.replace(".md", "/") for nav_path in navigation_paths]
+
+    return navigation_paths

--- a/tests/context.py
+++ b/tests/context.py
@@ -11,3 +11,4 @@ sys.path.insert(
 
 # pylint: disable=wrong-import-position,unused-import
 from plugin import ExcludeSearch
+from utils import iterate_all_values, explode_navigation

--- a/tests/globals.py
+++ b/tests/globals.py
@@ -37,6 +37,23 @@ RESOLVED_IGNORED_CHAPTERS = [
 EXCLUDE_UNREFERENCED = False
 EXCLUDE_TAGS = False
 
+NAVIGATION = [
+    {"index": "index.md"},
+    {"chapter_exclude_all": "chapter_exclude_all.md"},
+    {"all_dir": "all_dir/all_dir.md"},
+    {
+        "toplvl_chapter": [
+            "toplvl_chapter/file_in_toplvl_chapter.md",
+            {
+                "sub_chapter": [
+                    "toplvl_chapter/sub_chapter/file1_in_sub_chapter.md",
+                    "toplvl_chapter/sub_chapter/file2_in_sub_chapter.md",
+                ]
+            },
+        ]
+    },
+]
+
 INCLUDED_RECORDS = [
     {"location": "", "text": "Index Hello, hello", "title": "index"},
     {"location": "#index", "text": "Hello, hello", "title": "Index"},

--- a/tests/globals.py
+++ b/tests/globals.py
@@ -40,7 +40,6 @@ EXCLUDE_TAGS = False
 NAVIGATION = [
     {"index": "index.md"},
     {"chapter_exclude_all": "chapter_exclude_all.md"},
-    {"all_dir": "all_dir/all_dir.md"},
     {
         "toplvl_chapter": [
             "toplvl_chapter/file_in_toplvl_chapter.md",

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -9,6 +9,7 @@ from .globals import (
     RESOLVED_EXCLUDED_RECORDS,
     TO_IGNORE,
     RESOLVED_IGNORED_CHAPTERS,
+    NAVIGATION,
     EXCLUDE_UNREFERENCED,
     EXCLUDE_TAGS,
     INCLUDED_RECORDS,
@@ -54,6 +55,11 @@ def test_check_config_raises_no_exclusion():
     )
     with pytest.raises(ValueError):
         ex.check_config(plugins=["search"])
+
+
+def test_explode_navigation():
+    exploded_navigation = ExcludeSearch.explode_navigation(navigation=NAVIGATION)
+    assert len(exploded_navigation)
 
 
 def test_resolve_excluded_records():

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -9,7 +9,6 @@ from .globals import (
     RESOLVED_EXCLUDED_RECORDS,
     TO_IGNORE,
     RESOLVED_IGNORED_CHAPTERS,
-    NAVIGATION,
     EXCLUDE_UNREFERENCED,
     EXCLUDE_TAGS,
     INCLUDED_RECORDS,
@@ -55,11 +54,6 @@ def test_check_config_raises_no_exclusion():
     )
     with pytest.raises(ValueError):
         ex.check_config(plugins=["search"])
-
-
-def test_explode_navigation():
-    exploded_navigation = ExcludeSearch.explode_navigation(navigation=NAVIGATION)
-    assert len(exploded_navigation)
 
 
 def test_resolve_excluded_records():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,23 @@
+from .globals import NAVIGATION
+from .context import iterate_all_values, explode_navigation
+
+
+def test_iterate_all_values():
+    nav = {"a": ["aa", {"b": ["cc", {"d": ["ee", "ff", {"d": ["gg", "hh"]}]}]}]}
+
+    nav_paths = list(iterate_all_values(nested_dict=nav))
+    assert isinstance(nav_paths, list)
+    assert nav_paths == ["aa", "cc", "ee", "ff", "gg", "hh"]
+
+
+def test_explode_navigation():
+
+    nav_paths = explode_navigation(navigation=NAVIGATION)
+    assert isinstance(nav_paths, list)
+    assert nav_paths == [
+        "index/",
+        "chapter_exclude_all/",
+        "toplvl_chapter/file_in_toplvl_chapter/",
+        "toplvl_chapter/sub_chapter/file1_in_sub_chapter/",
+        "toplvl_chapter/sub_chapter/file2_in_sub_chapter/",
+    ]


### PR DESCRIPTION
Adresses https://github.com/chrieke/mkdocs-exclude-search/issues/25 when building with 0.6.0 with multiple subchapters in mkdocs navigation, which was not covered by the navigation chapters - unresolved files comparison.