### PR TITLE
Fix ignore default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ pip show mkdocs-exclude-search
 
 ## Versions
 
+### [0.6.2](https://pypi.org/project/mkdocs-exclude-search/) (2021-12-23)
+- Fixes issue in 0.6.1 when building with no ignored files defined.
+
 ### [0.6.1](https://pypi.org/project/mkdocs-exclude-search/) (2021-12-22)
 - Fixes issue in 0.6.0 when building with multiple subchapters in the navigation.
   

--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">86%</text>
-        <text x="80" y="14">86%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">85%</text>
+        <text x="80" y="14">85%</text>
     </g>
 </svg>

--- a/mkdocs_exclude_search/plugin.py
+++ b/mkdocs_exclude_search/plugin.py
@@ -248,10 +248,12 @@ class ExcludeSearch(BasePlugin):
         with open(search_index_fp, "r") as f:
             search_index = json.load(f)
 
-        to_exclude = self.resolve_excluded_records(to_exclude=self.config["exclude"])
-        to_ignore = None
-        if self.config["ignore"]:
-            to_ignore = self.resolve_ignored_chapters(to_ignore=self.config["ignore"])
+        to_exclude = self.config["exclude"]
+        if to_exclude:
+            to_exclude = self.resolve_excluded_records(to_exclude=to_exclude)
+        to_ignore = self.config["ignore"]
+        if to_ignore:
+            to_ignore = self.resolve_ignored_chapters(to_ignore=to_ignore)
 
         navigation_items = explode_navigation(navigation=config.data["nav"])
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="mkdocs-exclude-search",
-    version="0.6.1",
+    version="0.6.2",
     description="A mkdocs plugin that lets you exclude selected files or sections "
     "from the search index.",
     long_description=LONG_DESCRIPTION,


### PR DESCRIPTION
Fixes https://github.com/chrieke/mkdocs-exclude-search/issues/28 when no ignored files are defined, default was None instead of empty list.