### PR TITLE
Better validation exceptions

### DIFF
--- a/mkdocs_exclude_search/plugin.py
+++ b/mkdocs_exclude_search/plugin.py
@@ -57,6 +57,15 @@ class ExcludeSearch(BasePlugin):
             logger.info(message)
             raise ValueError(message)
 
+        try:
+            if self.config["ignore"]:
+                if not all("#" in x for x in self.config["ignore"]):
+                    message = "Ignored elements of mkdocs-exclude-search can only be headers (containing `#`)."
+                    logger.info(message)
+                    raise ValueError(message)
+        except KeyError:
+            pass
+
     @staticmethod
     def resolve_excluded_records(
         to_exclude: List[str],

--- a/mkdocs_exclude_search/plugin.py
+++ b/mkdocs_exclude_search/plugin.py
@@ -53,16 +53,24 @@ class ExcludeSearch(BasePlugin):
             and not self.config["exclude_unreferenced"]
             and not self.config["exclude_tags"]
         ):
-            message = "No excluded search entries selected for mkdocs-exclude-search."
+            message = (
+                "No excluded search entries selected for mkdocs-exclude-search, "
+                "the plugin has no effect!"
+            )
             logger.info(message)
             raise ValueError(message)
 
         try:
             if self.config["ignore"]:
-                if not all("#" in x for x in self.config["ignore"]):
-                    message = "Ignored elements of mkdocs-exclude-search can only be headers (containing `#`)."
-                    logger.info(message)
-                    raise ValueError(message)
+                invalid_ignored = [x for x in self.config["ignore"] if "#" not in x]
+                message = (
+                    f"mkdocs-exclude-search configuration for `ignore` can only be "
+                    f"headers (containing `#`), the following entries will be ignored: {invalid_ignored}"
+                )
+                logger.info(message)
+                self.config["ignore"] = [
+                    x for x in self.config["ignore"] if not x in invalid_ignored
+                ]
         except KeyError:
             pass
 

--- a/mkdocs_exclude_search/plugin.py
+++ b/mkdocs_exclude_search/plugin.py
@@ -36,9 +36,9 @@ class ExcludeSearch(BasePlugin):
         self.enabled = True
         self.total_time = 0
 
-    def check_config(self, plugins: List[str]):
+    def validate_config(self, plugins: List[str]):
         """
-        Check plugin configuration.
+        Validate mkdocs-exclude-search plugin configuration.
         """
         if not "search" in plugins:
             message = (
@@ -250,7 +250,7 @@ class ExcludeSearch(BasePlugin):
     def on_post_build(self, config):
         # at mkdocs buildtime, self.config does not contain the same as config
         try:
-            self.check_config(plugins=config["plugins"])
+            self.validate_config(plugins=config["plugins"])
         except ValueError:
             return config
 

--- a/mkdocs_exclude_search/plugin.py
+++ b/mkdocs_exclude_search/plugin.py
@@ -47,6 +47,7 @@ class ExcludeSearch(BasePlugin):
             )
             logger.debug(message)
             raise ValueError(message)
+
         if (
             not self.config["exclude"]
             and not self.config["exclude_unreferenced"]

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -65,7 +65,24 @@ def test_check_config_raises_no_exclusion():
         str(error.value)
         == "No excluded search entries selected for mkdocs-exclude-search."
     )
+
+
+def test_check_config_raises_ignore_is_not_header():
+    ex = ExcludeSearch()
+    ex.config = dict(
+        {
+            "exclude": TO_EXCLUDE,
+            "ignore": ["not_a_header"],
+            "exclude_unreferenced": EXCLUDE_UNREFERENCED,
+            "exclude_tags": EXCLUDE_TAGS,
+        }
+    )
+    with pytest.raises(ValueError) as error:
         ex.check_config(plugins=["search"])
+    assert (
+        str(error.value)
+        == "Ignored elements of mkdocs-exclude-search can only be headers (containing `#`)."
+    )
 
 
 def test_resolve_excluded_records():

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -63,26 +63,25 @@ def test_validate_config_raises_no_exclusion():
         ex.validate_config(plugins=["search"])
     assert (
         str(error.value)
-        == "No excluded search entries selected for mkdocs-exclude-search."
+        == "No excluded search entries selected for mkdocs-exclude-search, "
+        "the plugin has no effect!"
     )
 
 
-def test_validate_config_raises_ignore_is_not_header():
+def test_validate_config_pops_ignore_is_not_header():
     ex = ExcludeSearch()
     ex.config = dict(
         {
             "exclude": TO_EXCLUDE,
-            "ignore": ["not_a_header"],
+            "ignore": ["not_a_header.md", "dir/file.md#header"],
             "exclude_unreferenced": EXCLUDE_UNREFERENCED,
             "exclude_tags": EXCLUDE_TAGS,
         }
     )
-    with pytest.raises(ValueError) as error:
-        ex.validate_config(plugins=["search"])
-    assert (
-        str(error.value)
-        == "Ignored elements of mkdocs-exclude-search can only be headers (containing `#`)."
-    )
+    ex.validate_config(plugins=["search"])
+    assert "not_a_header.md" not in ex.config["ignore"]
+    assert "dir/file.md#header" in ex.config["ignore"]
+    assert len(ex.config["ignore"]) == 1
 
 
 def test_resolve_excluded_records():

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -42,8 +42,12 @@ def test_check_config(exclude, exclude_unreferenced, exclude_tags):
 
 def test_check_config_raises_search_deactivated():
     ex = ExcludeSearch()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as error:
         ex.check_config(plugins=["abc"])
+    assert (
+        str(error.value)
+        == "mkdocs-exclude-search plugin is activated but has no effect as search plugin is deactivated!"
+    )
 
 
 def test_check_config_raises_no_exclusion():
@@ -55,7 +59,12 @@ def test_check_config_raises_no_exclusion():
             "exclude_tags": EXCLUDE_TAGS,
         }
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as error:
+        ex.check_config(plugins=["search"])
+    assert (
+        str(error.value)
+        == "No excluded search entries selected for mkdocs-exclude-search."
+    )
         ex.check_config(plugins=["search"])
 
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -28,7 +28,7 @@ from .globals import (
         ([], True, True),
     ],
 )
-def test_check_config(exclude, exclude_unreferenced, exclude_tags):
+def test_validate_config(exclude, exclude_unreferenced, exclude_tags):
     ex = ExcludeSearch()
     ex.config = dict(
         {
@@ -37,20 +37,20 @@ def test_check_config(exclude, exclude_unreferenced, exclude_tags):
             "exclude_tags": exclude_tags,
         }
     )
-    ex.check_config(plugins=["search"])
+    ex.validate_config(plugins=["search"])
 
 
-def test_check_config_raises_search_deactivated():
+def test_validate_config_raises_search_deactivated():
     ex = ExcludeSearch()
     with pytest.raises(ValueError) as error:
-        ex.check_config(plugins=["abc"])
+        ex.validate_config(plugins=["abc"])
     assert (
         str(error.value)
         == "mkdocs-exclude-search plugin is activated but has no effect as search plugin is deactivated!"
     )
 
 
-def test_check_config_raises_no_exclusion():
+def test_validate_config_raises_no_exclusion():
     ex = ExcludeSearch()
     ex.config = dict(
         {
@@ -60,14 +60,14 @@ def test_check_config_raises_no_exclusion():
         }
     )
     with pytest.raises(ValueError) as error:
-        ex.check_config(plugins=["search"])
+        ex.validate_config(plugins=["search"])
     assert (
         str(error.value)
         == "No excluded search entries selected for mkdocs-exclude-search."
     )
 
 
-def test_check_config_raises_ignore_is_not_header():
+def test_validate_config_raises_ignore_is_not_header():
     ex = ExcludeSearch()
     ex.config = dict(
         {
@@ -78,7 +78,7 @@ def test_check_config_raises_ignore_is_not_header():
         }
     )
     with pytest.raises(ValueError) as error:
-        ex.check_config(plugins=["search"])
+        ex.validate_config(plugins=["search"])
     assert (
         str(error.value)
         == "Ignored elements of mkdocs-exclude-search can only be headers (containing `#`)."


### PR DESCRIPTION
- Small refactor validate_config
- Validate that ignore is a header, and pop from used ignore list if not