### PR TITLE
Fix nav section no name

### DIFF
--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">97%</text>
-        <text x="80" y="14">97%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">96%</text>
+        <text x="80" y="14">96%</text>
     </g>
 </svg>

--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">96%</text>
-        <text x="80" y="14">96%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">97%</text>
+        <text x="80" y="14">97%</text>
     </g>
 </svg>

--- a/docs/without_nav_name.md
+++ b/docs/without_nav_name.md
@@ -1,0 +1,5 @@
+# without_nav_name file heading1 Ain
+
+This is an example of a file that in the nav section is provided without a name
+
+## without_nav_name file heading2 Ain

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: My Docs
 
 nav:
     - index: index.md
+    - without_nav_name.md
     - chapter_exclude_all: chapter_exclude_all.md
     - chapter_exclude_heading2: chapter_exclude_heading2.md
     - dir_chapter_exclude_all: dir/dir_chapter_exclude_all.md

--- a/mkdocs_exclude_search/plugin.py
+++ b/mkdocs_exclude_search/plugin.py
@@ -273,9 +273,8 @@ class ExcludeSearch(BasePlugin):
         if to_ignore:
             to_ignore = self.resolve_ignored_chapters(to_ignore=to_ignore)
 
-        nav = config.data["nav"]
-        if nav is not None:
-            navigation_items = explode_navigation(navigation=nav)
+        if self.config["exclude_unreferenced"] and config.data["nav"] is not None:
+            navigation_items = explode_navigation(navigation=config.data["nav"])
         else:
             navigation_items = []
 

--- a/mkdocs_exclude_search/utils.py
+++ b/mkdocs_exclude_search/utils.py
@@ -28,12 +28,19 @@ def explode_navigation(navigation: list) -> List[str]:
     navigation_paths = []
 
     for chapter in navigation:
-        chapter_paths = list(chapter.values())[0]
-        if isinstance(chapter_paths, str):
-            navigation_paths.append(chapter_paths)
-        elif isinstance(chapter_paths, list):
-            exploded_chapter_paths = iterate_all_values(nested_dict=chapter)
-            navigation_paths.extend(exploded_chapter_paths)
+        if isinstance(chapter, str):
+            # e.g. - index.md   (without name in nav)
+            navigation_paths.append(chapter)
+        elif isinstance(chapter, dict):
+            chapter_paths = list(chapter.values())[0]
+            if isinstance(chapter_paths, str):
+                # e.g. - chapter_exclude_all: chapter_exclude_all.md
+                navigation_paths.append(chapter_paths)
+            elif isinstance(chapter_paths, list):
+                # e.g. - toplvl_chapter:
+                #         - toplvl_chapter/file_in_toplvl_chapter.md
+                exploded_chapter_paths = iterate_all_values(nested_dict=chapter)
+                navigation_paths.extend(exploded_chapter_paths)
 
     navigation_paths = [nav_path.replace(".md", "/") for nav_path in navigation_paths]
 

--- a/tests/globals.py
+++ b/tests/globals.py
@@ -39,6 +39,7 @@ EXCLUDE_TAGS = False
 
 NAVIGATION = [
     {"index": "index.md"},
+    "without_nav_name.md",
     {"chapter_exclude_all": "chapter_exclude_all.md"},
     {
         "toplvl_chapter": [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,6 +16,7 @@ def test_explode_navigation():
     assert isinstance(nav_paths, list)
     assert nav_paths == [
         "index/",
+        "without_nav_name/",
         "chapter_exclude_all/",
         "toplvl_chapter/file_in_toplvl_chapter/",
         "toplvl_chapter/sub_chapter/file1_in_sub_chapter/",


### PR DESCRIPTION
Fixes https://github.com/chrieke/mkdocs-exclude-search/issues/35, if a chapter in the nav section is provided without definition of a chapter name. See [here](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation) for the different options to define the nav section.