### PR TITLE
Fix search plugin validation namespace

### DIFF
--- a/mkdocs_exclude_search/plugin.py
+++ b/mkdocs_exclude_search/plugin.py
@@ -40,7 +40,7 @@ class ExcludeSearch(BasePlugin):
         """
         Validate mkdocs-exclude-search plugin configuration.
         """
-        if not "search" in plugins or "material/search" in plugins:
+        if not ("search" in plugins or "material/search" in plugins):
             message = (
                 "mkdocs-exclude-search plugin is activated but has no effect as "
                 "search plugin is deactivated!"

--- a/mkdocs_exclude_search/plugin.py
+++ b/mkdocs_exclude_search/plugin.py
@@ -255,6 +255,7 @@ class ExcludeSearch(BasePlugin):
 
         return included_records
 
+    # pylint: disable=arguments-differ
     def on_post_build(self, config):
         # at mkdocs buildtime, self.config does not contain the same as config
         try:

--- a/mkdocs_exclude_search/plugin.py
+++ b/mkdocs_exclude_search/plugin.py
@@ -40,7 +40,7 @@ class ExcludeSearch(BasePlugin):
         """
         Validate mkdocs-exclude-search plugin configuration.
         """
-        if not "search" in plugins:
+        if not "search" in plugins or "material/search" in plugins:
             message = (
                 "mkdocs-exclude-search plugin is activated but has no effect as "
                 "search plugin is deactivated!"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,7 +11,6 @@ def test_iterate_all_values():
 
 
 def test_explode_navigation():
-
     nav_paths = explode_navigation(navigation=NAVIGATION)
     assert isinstance(nav_paths, list)
     assert nav_paths == [


### PR DESCRIPTION
Fixes https://github.com/chrieke/mkdocs-exclude-search/issues/41

mkdocs-material introduced a new namespace, this results in the search-plugin being called `material/search` in the mkdocs config. The exclude plugin did not recognize the search plugin and therefore was deactivated.

Thanks @Paddy-Farmeye for reporting and debugging this!