### PR TITLE
Fix log filter issue with mkdocs >= 1.2

### DIFF
--- a/mkdocs_exclude_search/plugin.py
+++ b/mkdocs_exclude_search/plugin.py
@@ -1,19 +1,27 @@
 import json
 from pathlib import Path
-import logging
+
 from typing import List, Dict, Tuple, Union, Any
 from fnmatch import fnmatch
 
+import mkdocs
 from mkdocs.config import config_options
 from mkdocs.plugins import BasePlugin
-from mkdocs.utils import warning_filter
 
 from mkdocs_exclude_search.utils import explode_navigation
 
+from packaging.version import Version
+
+import logging
+logger = logging.getLogger("mkdocs.plugins.mkdocs-exclude-search")
+MKDOCS_LOG_VERSION = '1.2'
+if Version(mkdocs.__version__) < Version(MKDOCS_LOG_VERSION):
+    # filter doesn't do anything since that version
+    from mkdocs.utils import warning_filter
+    logger.addFilter(warning_filter)
+
 
 def get_logger():
-    logger = logging.getLogger("mkdocs.plugins.mkdocs-exclude-search")
-    logger.addFilter(warning_filter)
     return logger
 
 


### PR DESCRIPTION
This is basically a copy & paste fix from

https://github.com/fralau/mkdocs_macros_plugin/issues/173

It is meant to get rid of this (annoying) deprecation warning:

```
$ mkdocs build --strict
INFO    -  DeprecationWarning: warning_filter doesn't do anything since MkDocs 1.2 and will be removed soon. All messages on the `mkdocs` logger get counted automatically.
  File "/usr/local/lib/python3.11/site-packages/mkdocs_exclude_search/plugin.py", line 9, in <module>
    from mkdocs.utils import warning_filter
```

Frankencode... but tested OK with `mkdocs==1.5.2`.