### PR TITLE
Release 0.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ pip show mkdocs-exclude-search
 
 ## Versions
 
+### [0.6.6](https://pypi.org/project/mkdocs-exclude-search/) (2023-11-20)
+- Prevents long mkdocs logger deprecation warning (#45).
+
 ### [0.6.5](https://pypi.org/project/mkdocs-exclude-search/) (2023-02-04)
 - Fixes issue of search-plugin not being recognized, mkdocs-material adjusted search namespace (#42).
 

--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">97%</text>
-        <text x="80" y="14">97%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">95%</text>
+        <text x="80" y="14">95%</text>
     </g>
 </svg>

--- a/mkdocs_exclude_search/plugin.py
+++ b/mkdocs_exclude_search/plugin.py
@@ -1,27 +1,27 @@
 import json
 from pathlib import Path
-
+import logging
 from typing import List, Dict, Tuple, Union, Any
 from fnmatch import fnmatch
 
 import mkdocs
 from mkdocs.config import config_options
 from mkdocs.plugins import BasePlugin
+from packaging.version import Version
 
 from mkdocs_exclude_search.utils import explode_navigation
 
-from packaging.version import Version
-
-import logging
-logger = logging.getLogger("mkdocs.plugins.mkdocs-exclude-search")
-MKDOCS_LOG_VERSION = '1.2'
-if Version(mkdocs.__version__) < Version(MKDOCS_LOG_VERSION):
-    # filter doesn't do anything since that version
-    from mkdocs.utils import warning_filter
-    logger.addFilter(warning_filter)
-
 
 def get_logger():
+    logger = logging.getLogger("mkdocs.plugins.mkdocs-exclude-search")
+    MKDOCS_LOG_VERSION = "1.2"
+    if Version(mkdocs.__version__) < Version(MKDOCS_LOG_VERSION):
+        # filter doesn't do anything since that version
+        # pylint: disable=import-outside-toplevel, no-name-in-module
+        from mkdocs.utils import warning_filter
+
+        logger.addFilter(warning_filter)
+
     return logger
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="mkdocs-exclude-search",
-    version="0.6.5",
+    version="0.6.6",
     description="A mkdocs plugin that lets you exclude selected files or sections "
     "from the search index.",
     long_description=LONG_DESCRIPTION,


### PR DESCRIPTION
Minor release to prevent deprecation warning from mkdocs version, see https://github.com/chrieke/mkdocs-exclude-search/pull/45